### PR TITLE
Math: move IEquation and IDisplay to shared Abstractions

### DIFF
--- a/Fluxion.Core/App/QuickSimulations.cs
+++ b/Fluxion.Core/App/QuickSimulations.cs
@@ -6,6 +6,7 @@ using Fluxion.Features;
 // Trigonometry dependencies
 using Fluxion.Math.Trigonometry.Concepts;
 using Fluxion.Math.Trigonometry.Functions;
+using Fluxion.Math.Abstractions;
 using Fluxion.Math.Trigonometry.Sampling;
 
 namespace Fluxion.Core.App

--- a/Fluxion.Math/Abstractions/EquationAbstractions.cs
+++ b/Fluxion.Math/Abstractions/EquationAbstractions.cs
@@ -1,0 +1,20 @@
+﻿// Fluxion.Math/Abstractions/EquationAbstractions.cs
+namespace Fluxion.Math.Abstractions
+{
+    /// <summary>Contract for single-variable real functions f(x).</summary>
+    public interface IEquation
+    {
+        /// <summary>Evaluate f(x) for a given x.</summary>
+        double Evaluate(double x);
+
+        /// <summary>Returns true if parameters are valid (e.g., domain/NaN checks).</summary>
+        bool IsWellFormed();
+    }
+
+    /// <summary>Contract for a human-friendly display string.</summary>
+    public interface IDisplay
+    {
+        /// <summary>Pretty representation, e.g., "A·x + B".</summary>
+        string AsString(string variable = "x");
+    }
+}

--- a/Fluxion.Math/Algebra/Concepts/AlgebraModels.cs
+++ b/Fluxion.Math/Algebra/Concepts/AlgebraModels.cs
@@ -20,20 +20,6 @@ namespace Fluxion.Math.Algebra.Concepts
     }
 
     /// <summary>Base contract for 1-variable equations.</summary>
-    public interface IEquation
-    {
-        /// Evaluate f(x).
-        double Evaluate(double x);
-
-        /// Returns true if parameters describe a valid equation (e.g., domain constraints ok).
-        bool IsWellFormed();
-    }
-
-    /// <summary>Optional pretty name/output.</summary>
-    public interface IDisplay
-    {
-        string AsString(string variable = "x");
-    }
 
     // -------- Canonical models (parameters only) --------
 

--- a/Fluxion.Math/Algebra/Equations/Exponential.cs
+++ b/Fluxion.Math/Algebra/Equations/Exponential.cs
@@ -1,4 +1,5 @@
 ﻿// Fluxion.Math/Algebra/Equations/Exponential.cs
+using Fluxion.Math.Abstractions;
 using Fluxion.Math.Algebra.Concepts;
 using static System.Math;
 

--- a/Fluxion.Math/Algebra/Equations/Linear.cs
+++ b/Fluxion.Math/Algebra/Equations/Linear.cs
@@ -1,6 +1,6 @@
 ﻿// Fluxion.Math/Algebra/Equations/Linear.cs
 using Fluxion.Math.Algebra.Concepts;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     public sealed class Linear : IEquation, IDisplay

--- a/Fluxion.Math/Algebra/Equations/Logarithmic.cs
+++ b/Fluxion.Math/Algebra/Equations/Logarithmic.cs
@@ -2,7 +2,7 @@
 using System;
 using Fluxion.Math.Algebra.Concepts;
 using static System.Math;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     public sealed class Logarithmic : IEquation, IDisplay

--- a/Fluxion.Math/Algebra/Equations/Polynomial.cs
+++ b/Fluxion.Math/Algebra/Equations/Polynomial.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 using Fluxion.Math.Algebra.Concepts;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     /// <summary>

--- a/Fluxion.Math/Algebra/Equations/Quadratic.cs
+++ b/Fluxion.Math/Algebra/Equations/Quadratic.cs
@@ -1,7 +1,7 @@
 ﻿// Fluxion.Math/Algebra/Equations/Quadratic.cs
 using Fluxion.Math.Algebra.Concepts;
 using static System.Math;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     public sealed class Quadratic : IEquation, IDisplay

--- a/Fluxion.Math/Algebra/Equations/Rational.cs
+++ b/Fluxion.Math/Algebra/Equations/Rational.cs
@@ -1,6 +1,6 @@
 ﻿// Fluxion.Math/Algebra/Equations/Rational.cs
 using Fluxion.Math.Algebra.Concepts;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     public sealed class Rational : IEquation, IDisplay

--- a/Fluxion.Math/Algebra/Equations/SystemOfEquations2x2.cs
+++ b/Fluxion.Math/Algebra/Equations/SystemOfEquations2x2.cs
@@ -1,6 +1,6 @@
 ﻿// Fluxion.Math/Algebra/Equations/SystemOfEquations2x2.cs
 using Fluxion.Math.Algebra.Concepts;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Equations
 {
     public sealed class SystemOfEquations2x2 : IDisplay

--- a/Fluxion.Math/Algebra/Operations/Substitution.cs
+++ b/Fluxion.Math/Algebra/Operations/Substitution.cs
@@ -1,6 +1,6 @@
 ﻿// Fluxion.Math/Algebra/Operations/Substitution.cs
 using Fluxion.Math.Algebra.Concepts;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Algebra.Operations
 {
     public static class Substitution

--- a/Fluxion.Math/Trigonometry/Functions/CosineEquation.cs
+++ b/Fluxion.Math/Trigonometry/Functions/CosineEquation.cs
@@ -1,10 +1,10 @@
-﻿//Fluxion.Math/Trigonometry/Functions/CosineEquation.cs
-using Fluxion.Math.Algebra.Concepts;
+﻿using Fluxion.Math.Abstractions;
 using Fluxion.Math.Trigonometry.Concepts;
 using System;
 
 namespace Fluxion.Math.Trigonometry.Functions
 {
+    /// <summary>f(x) = Amplitude * cos(Frequency * x + Phase) + VerticalOffset</summary>
     public readonly struct CosineEquation : IEquation, IDisplay
     {
         public CosineModel Model { get; }
@@ -15,8 +15,8 @@ namespace Fluxion.Math.Trigonometry.Functions
             => Model.Amplitude * System.Math.Cos(Model.Frequency * x + Model.Phase) + Model.VerticalOffset;
 
         public bool IsWellFormed()
-            => !(double.IsNaN(Model.Amplitude) || double.IsNaN(Model.Frequency)
-                 || double.IsNaN(Model.Phase) || double.IsNaN(Model.VerticalOffset));
+            => !(double.IsNaN(Model.Amplitude) || double.IsNaN(Model.Frequency) ||
+                 double.IsNaN(Model.Phase) || double.IsNaN(Model.VerticalOffset));
 
         public string AsString(string variable = "x")
             => $"{Model.Amplitude}·cos({Model.Frequency}·{variable} + {Model.Phase}) + {Model.VerticalOffset}";

--- a/Fluxion.Math/Trigonometry/Functions/SineEquation.cs
+++ b/Fluxion.Math/Trigonometry/Functions/SineEquation.cs
@@ -3,7 +3,7 @@
 using Fluxion.Math.Algebra.Concepts;
 using Fluxion.Math.Trigonometry.Concepts;
 using System;
-
+using Fluxion.Math.Abstractions;
 namespace Fluxion.Math.Trigonometry.Functions
 {
     public readonly struct SineEquation : IEquation, IDisplay


### PR DESCRIPTION
- Add Fluxion.Math/Abstractions/EquationAbstractions.cs with IEquation + IDisplay
- Remove legacy interface copies from Algebra/Trigonometry
- Update Algebra/Trigonometry equation wrappers to use Fluxion.Math.Abstractions
- (Optional) Add GlobalUsings.cs for simpler imports