### PR TITLE
Fix WPF desktop project and exclude nested build files

### DIFF
--- a/Desktop/App.xaml
+++ b/Desktop/App.xaml
@@ -1,0 +1,9 @@
+<Application x:Class="Fluxion.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+
+    <Application.Resources>
+    </Application.Resources>
+
+</Application>

--- a/Desktop/App.xaml.cs
+++ b/Desktop/App.xaml.cs
@@ -1,0 +1,7 @@
+﻿using System.Windows;
+
+namespace Fluxion.Desktop;
+
+public partial class App : Application
+{
+}

--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+
+    <RootNamespace>Fluxion.Desktop</RootNamespace>
+    <AssemblyName>Fluxion.Desktop</AssemblyName>
+
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK.GLWpfControl"
+                      Version="4.3.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fluxion.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Desktop/GraphRequest.cs
+++ b/Desktop/GraphRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace Fluxion.Desktop;
+
+public sealed record GraphRequest(
+    string Expression,
+    double MinimumX,
+    double MaximumX,
+    int Resolution,
+    bool Wireframe,
+    bool ShowAxes,
+    bool ShowGrid);

--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -1,0 +1,178 @@
+﻿<Window x:Class="Fluxion.Desktop.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:gl="clr-namespace:OpenTK.Wpf;assembly=GLWpfControl"
+        Title="Fluxion"
+        Width="1400"
+        Height="850"
+        MinWidth="900"
+        MinHeight="600"
+        WindowStartupLocation="CenterScreen">
+
+    <Grid Background="#181818">
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Top toolbar -->
+        <Border Grid.Row="0"
+                Padding="10"
+                Background="#242424">
+
+            <StackPanel Orientation="Horizontal">
+
+                <Button Content="Plot"
+                        Width="90"
+                        Margin="0,0,10,0"
+                        Click="Plot_Click"/>
+
+                <Button Content="Clear"
+                        Width="90"
+                        Margin="0,0,10,0"
+                        Click="Clear_Click"/>
+
+                <Button Content="Reset Camera"
+                        Width="120"
+                        Click="ResetCamera_Click"/>
+
+            </StackPanel>
+
+        </Border>
+
+        <!-- Main area -->
+        <Grid Grid.Row="1">
+
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Settings panel -->
+            <Border Grid.Column="0"
+                    Padding="18"
+                    Background="#1D1D1D">
+
+                <StackPanel>
+
+                    <TextBlock Text="Graph Settings"
+                               Margin="0,0,0,22"
+                               FontSize="24"
+                               FontWeight="Bold"
+                               Foreground="White"/>
+
+                    <TextBlock Text="Function"
+                               Margin="0,0,0,6"
+                               Foreground="#DDDDDD"/>
+
+                    <TextBox x:Name="FunctionBox"
+                             Height="40"
+                             Padding="8"
+                             FontFamily="Consolas"
+                             FontSize="16"
+                             Text="sin(x)"/>
+
+                    <TextBlock Text="Graph type"
+                               Margin="0,18,0,6"
+                               Foreground="#DDDDDD"/>
+
+                    <ComboBox x:Name="GraphTypeBox"
+                              Height="34"
+                              SelectedIndex="0">
+
+                        <ComboBoxItem Content="2D Function"/>
+                        <ComboBoxItem Content="3D Surface"/>
+
+                    </ComboBox>
+
+                    <TextBlock Text="X minimum"
+                               Margin="0,18,0,6"
+                               Foreground="#DDDDDD"/>
+
+                    <TextBox x:Name="XMinBox"
+                             Height="34"
+                             Padding="8"
+                             Text="-10"/>
+
+                    <TextBlock Text="X maximum"
+                               Margin="0,18,0,6"
+                               Foreground="#DDDDDD"/>
+
+                    <TextBox x:Name="XMaxBox"
+                             Height="34"
+                             Padding="8"
+                             Text="10"/>
+
+                    <TextBlock Text="Resolution"
+                               Margin="0,18,0,6"
+                               Foreground="#DDDDDD"/>
+
+                    <Slider x:Name="ResolutionSlider"
+                            Minimum="25"
+                            Maximum="1000"
+                            Value="200"
+                            ValueChanged="ResolutionSlider_ValueChanged"/>
+
+                    <TextBlock x:Name="ResolutionText"
+                               Margin="0,7,0,14"
+                               Text="Resolution: 200"
+                               Foreground="#BBBBBB"/>
+
+                    <CheckBox x:Name="WireframeBox"
+                              Margin="0,6"
+                              Content="Wireframe"
+                              IsChecked="True"
+                              Foreground="White"/>
+
+                    <CheckBox x:Name="ShowAxesBox"
+                              Margin="0,6"
+                              Content="Show axes"
+                              IsChecked="True"
+                              Foreground="White"/>
+
+                    <CheckBox x:Name="ShowGridBox"
+                              Margin="0,6"
+                              Content="Show grid"
+                              IsChecked="True"
+                              Foreground="White"/>
+
+                </StackPanel>
+
+            </Border>
+
+            <GridSplitter Grid.Column="1"
+                          HorizontalAlignment="Stretch"
+                          Background="#444444"/>
+
+            <!-- OpenGL viewport -->
+            <Border Grid.Column="2"
+                    Margin="10"
+                    BorderBrush="#444444"
+                    BorderThickness="1"
+                    Background="Black">
+
+                <gl:GLWpfControl x:Name="Viewport"
+                                 Focusable="True"
+                                 Render="Viewport_Render"/>
+
+            </Border>
+
+        </Grid>
+
+        <!-- Status bar -->
+        <Border Grid.Row="2"
+                Padding="8"
+                Background="#202020">
+
+            <TextBlock x:Name="StatusText"
+                       Text="Ready"
+                       Foreground="#DDDDDD"/>
+
+        </Border>
+
+    </Grid>
+
+</Window>

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -1,0 +1,489 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+using Fluxion.src.Rendering.Draw;
+using Fluxion.src.Rendering.Visualize2D;
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Wpf;
+
+using Matrix4 = OpenTK.Mathematics.Matrix4;
+using NumericsVector2 = System.Numerics.Vector2;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Fluxion.Desktop;
+
+public partial class MainWindow : Window
+{
+    private CurveRenderer2D? _curveRenderer;
+    private Plot2D? _functionPlot;
+
+    private readonly List<Plot2D> _gridPlots = new();
+    private readonly List<Plot2D> _axisPlots = new();
+
+    private double _xMinimum = -10;
+    private double _xMaximum = 10;
+    private double _yMinimum = -1.25;
+    private double _yMaximum = 1.25;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        /*
+         * This was the missing operation.
+         *
+         * GLWpfControl does not automatically create and start its
+         * OpenGL rendering context. Start() must be called explicitly.
+         */
+        var settings = new GLWpfControlSettings
+        {
+            MajorVersion = 4,
+            MinorVersion = 6,
+            RenderContinuously = true
+        };
+
+        Viewport.Start(settings);
+
+        BuildPlot();
+    }
+
+    private void Viewport_Render(TimeSpan delta)
+    {
+        if (Viewport.ActualWidth <= 0 || Viewport.ActualHeight <= 0)
+        {
+            return;
+        }
+
+        DpiScale dpi = VisualTreeHelper.GetDpi(Viewport);
+
+        int width = Math.Max(
+            1,
+            (int)(Viewport.ActualWidth * dpi.DpiScaleX));
+
+        int height = Math.Max(
+            1,
+            (int)(Viewport.ActualHeight * dpi.DpiScaleY));
+
+        GL.Viewport(0, 0, width, height);
+
+        GL.Disable(EnableCap.DepthTest);
+
+        GL.ClearColor(
+            0.055f,
+            0.060f,
+            0.075f,
+            1.0f);
+
+        GL.Clear(
+            ClearBufferMask.ColorBufferBit |
+            ClearBufferMask.DepthBufferBit);
+
+        /*
+         * CurveRenderer2D creates shaders, a VAO and a VBO.
+         * It must therefore be created only after Start() has created
+         * an active OpenGL context.
+         */
+        _curveRenderer ??= new CurveRenderer2D();
+
+        Matrix4 projection =
+            Matrix4.CreateOrthographicOffCenter(
+                (float)_xMinimum,
+                (float)_xMaximum,
+                (float)_yMinimum,
+                (float)_yMaximum,
+                -1.0f,
+                1.0f);
+
+        if (ShowGridBox.IsChecked == true)
+        {
+            foreach (Plot2D gridLine in _gridPlots)
+            {
+                _curveRenderer.Draw(gridLine, projection);
+            }
+        }
+
+        if (ShowAxesBox.IsChecked == true)
+        {
+            foreach (Plot2D axisLine in _axisPlots)
+            {
+                _curveRenderer.Draw(axisLine, projection);
+            }
+        }
+
+        if (_functionPlot is not null)
+        {
+            _curveRenderer.Draw(_functionPlot, projection);
+        }
+    }
+
+    private void Plot_Click(
+        object sender,
+        RoutedEventArgs e)
+    {
+        BuildPlot();
+    }
+
+    private void Clear_Click(
+        object sender,
+        RoutedEventArgs e)
+    {
+        _functionPlot = null;
+
+        _gridPlots.Clear();
+        _axisPlots.Clear();
+
+        StatusText.Text = "Graph cleared";
+
+        Viewport.InvalidateVisual();
+    }
+
+    private void ResetCamera_Click(
+        object sender,
+        RoutedEventArgs e)
+    {
+        XMinBox.Text = "-10";
+        XMaxBox.Text = "10";
+
+        BuildPlot();
+    }
+
+    private void ResolutionSlider_ValueChanged(
+        object sender,
+        RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (ResolutionText is null)
+        {
+            return;
+        }
+
+        ResolutionText.Text =
+            $"Resolution: {(int)e.NewValue}";
+    }
+
+    private void BuildPlot()
+    {
+        try
+        {
+            if (GraphTypeBox.SelectedIndex != 0)
+            {
+                throw new NotSupportedException(
+                    "The WPF viewport is currently connected to the 2D renderer. Select 2D Function.");
+            }
+
+            if (!TryParseNumber(XMinBox.Text, out double xMinimum))
+            {
+                throw new FormatException(
+                    "X minimum is not a valid number.");
+            }
+
+            if (!TryParseNumber(XMaxBox.Text, out double xMaximum))
+            {
+                throw new FormatException(
+                    "X maximum is not a valid number.");
+            }
+
+            if (xMinimum >= xMaximum)
+            {
+                throw new ArgumentException(
+                    "X minimum must be smaller than X maximum.");
+            }
+
+            _xMinimum = xMinimum;
+            _xMaximum = xMaximum;
+
+            int samples = Math.Max(
+                25,
+                (int)ResolutionSlider.Value);
+
+            Func<double, double> function =
+                ParseFunction(FunctionBox.Text);
+
+            _functionPlot =
+                Plot2DFactory.Function(
+                    function,
+                    _xMinimum,
+                    _xMaximum,
+                    samples,
+                    new PlotStyle
+                    {
+                        Lines = true,
+                        Points = false,
+                        Width = 2.5f,
+                        Rgb = new NumericsVector3(
+                            0.20f,
+                            0.80f,
+                            1.00f)
+                    });
+
+            CalculateYBounds();
+            BuildGridAndAxes();
+
+            StatusText.Text =
+                $"Plotting {FunctionBox.Text.Trim()}";
+
+            Viewport.InvalidateVisual();
+        }
+        catch (Exception exception)
+        {
+            StatusText.Text = exception.Message;
+
+            MessageBox.Show(
+                exception.Message,
+                "Unable to plot function",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+        }
+    }
+
+    private void CalculateYBounds()
+    {
+        if (_functionPlot is null)
+        {
+            _yMinimum = -1;
+            _yMaximum = 1;
+            return;
+        }
+
+        double[] finiteValues = _functionPlot.Points
+            .Select(point => (double)point.Y)
+            .Where(value =>
+                double.IsFinite(value) &&
+                Math.Abs(value) < 1_000_000)
+            .ToArray();
+
+        if (finiteValues.Length == 0)
+        {
+            _yMinimum = -1;
+            _yMaximum = 1;
+            return;
+        }
+
+        double minimum = finiteValues.Min();
+        double maximum = finiteValues.Max();
+
+        double range = maximum - minimum;
+
+        if (range < 0.000001)
+        {
+            range = 2;
+        }
+
+        double padding = range * 0.15;
+
+        _yMinimum = minimum - padding;
+        _yMaximum = maximum + padding;
+
+        /*
+         * Keep zero visible when the function is close to zero,
+         * which makes functions such as sin(x) easier to read.
+         */
+        if (_yMinimum > 0 && _yMinimum < range)
+        {
+            _yMinimum = 0;
+        }
+
+        if (_yMaximum < 0 && Math.Abs(_yMaximum) < range)
+        {
+            _yMaximum = 0;
+        }
+    }
+
+    private void BuildGridAndAxes()
+    {
+        _gridPlots.Clear();
+        _axisPlots.Clear();
+
+        double xStep =
+            CalculateNiceStep(_xMinimum, _xMaximum);
+
+        double yStep =
+            CalculateNiceStep(_yMinimum, _yMaximum);
+
+        double firstX =
+            Math.Ceiling(_xMinimum / xStep) * xStep;
+
+        for (double x = firstX;
+             x <= _xMaximum + 0.000001;
+             x += xStep)
+        {
+            _gridPlots.Add(
+                CreateLine(
+                    (float)x,
+                    (float)_yMinimum,
+                    (float)x,
+                    (float)_yMaximum,
+                    new NumericsVector3(
+                        0.17f,
+                        0.18f,
+                        0.21f),
+                    1.0f));
+        }
+
+        double firstY =
+            Math.Ceiling(_yMinimum / yStep) * yStep;
+
+        for (double y = firstY;
+             y <= _yMaximum + 0.000001;
+             y += yStep)
+        {
+            _gridPlots.Add(
+                CreateLine(
+                    (float)_xMinimum,
+                    (float)y,
+                    (float)_xMaximum,
+                    (float)y,
+                    new NumericsVector3(
+                        0.17f,
+                        0.18f,
+                        0.21f),
+                    1.0f));
+        }
+
+        if (_xMinimum <= 0 && _xMaximum >= 0)
+        {
+            _axisPlots.Add(
+                CreateLine(
+                    0,
+                    (float)_yMinimum,
+                    0,
+                    (float)_yMaximum,
+                    new NumericsVector3(
+                        0.85f,
+                        0.85f,
+                        0.85f),
+                    2.0f));
+        }
+
+        if (_yMinimum <= 0 && _yMaximum >= 0)
+        {
+            _axisPlots.Add(
+                CreateLine(
+                    (float)_xMinimum,
+                    0,
+                    (float)_xMaximum,
+                    0,
+                    new NumericsVector3(
+                        0.85f,
+                        0.85f,
+                        0.85f),
+                    2.0f));
+        }
+    }
+
+    private static Plot2D CreateLine(
+        float x1,
+        float y1,
+        float x2,
+        float y2,
+        NumericsVector3 color,
+        float width)
+    {
+        var plot = new Plot2D(
+            new PlotStyle
+            {
+                Lines = true,
+                Points = false,
+                Width = width,
+                Rgb = color
+            });
+
+        plot.Points.Add(
+            new NumericsVector2(x1, y1));
+
+        plot.Points.Add(
+            new NumericsVector2(x2, y2));
+
+        return plot;
+    }
+
+    private static Func<double, double> ParseFunction(
+        string expression)
+    {
+        string normalized = expression
+            .Trim()
+            .ToLowerInvariant()
+            .Replace(" ", string.Empty);
+
+        return normalized switch
+        {
+            "sin(x)" or "sin" =>
+                System.Math.Sin,
+
+            "cos(x)" or "cos" =>
+                System.Math.Cos,
+
+            "tan(x)" or "tan" =>
+                System.Math.Tan,
+
+            "x" =>
+                x => x,
+
+            "x^2" or "x*x" =>
+                x => x * x,
+
+            "x^3" or "x*x*x" =>
+                x => x * x * x,
+
+            "abs(x)" =>
+                System.Math.Abs,
+
+            "sqrt(x)" =>
+                System.Math.Sqrt,
+
+            "1/x" =>
+                x => 1.0 / x,
+
+            _ => throw new NotSupportedException(
+                "Supported functions: sin(x), cos(x), tan(x), x, x^2, x^3, abs(x), sqrt(x), and 1/x.")
+        };
+    }
+
+    private static double CalculateNiceStep(
+        double minimum,
+        double maximum)
+    {
+        double span =
+            Math.Max(0.000001, maximum - minimum);
+
+        double roughStep = span / 10.0;
+
+        double magnitude =
+            Math.Pow(
+                10,
+                Math.Floor(
+                    Math.Log10(roughStep)));
+
+        double normalized = roughStep / magnitude;
+
+        double niceValue = normalized switch
+        {
+            < 1.5 => 1,
+            < 3.0 => 2,
+            < 7.0 => 5,
+            _ => 10
+        };
+
+        return niceValue * magnitude;
+    }
+
+    private static bool TryParseNumber(
+        string text,
+        out double result)
+    {
+        return
+            double.TryParse(
+                text,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out result)
+            ||
+            double.TryParse(
+                text,
+                NumberStyles.Float,
+                CultureInfo.CurrentCulture,
+                out result);
+    }
+}

--- a/Fluxion.csproj
+++ b/Fluxion.csproj
@@ -3,43 +3,95 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!--
+      The Desktop project and generated bin/obj files are inside
+      the Fluxion directory. Prevent this project from compiling them.
+    -->
+    <DefaultItemExcludes>
+      $(DefaultItemExcludes);
+      Desktop\**;
+      **\bin\**;
+      **\obj\**
+    </DefaultItemExcludes>
   </PropertyGroup>
 
+  <!-- Exclude documentation folders from compilation -->
   <ItemGroup>
     <Compile Remove="docs\**" />
     <Compile Remove="md\**" />
+
     <EmbeddedResource Remove="docs\**" />
     <EmbeddedResource Remove="md\**" />
+
     <None Remove="docs\**" />
     <None Remove="md\**" />
   </ItemGroup>
 
+  <!-- Explicitly exclude the nested Desktop project and generated files -->
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.6.0" />
-    <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluxionSharp" Version="2.0.0" />
-    <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
-    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.4" />
-    <PackageReference Include="TorchSharp" Version="0.105.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.analyzers" Version="1.24.0">
+    <Compile Remove="Desktop\**\*.cs" />
+    <Compile Remove="**\bin\**\*.cs" />
+    <Compile Remove="**\obj\**\*.cs" />
+
+    <EmbeddedResource Remove="Desktop\**" />
+    <EmbeddedResource Remove="**\bin\**" />
+    <EmbeddedResource Remove="**\obj\**" />
+
+    <None Remove="Desktop\**" />
+    <None Remove="**\bin\**" />
+    <None Remove="**\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions"
+                      Version="8.6.0" />
+
+    <PackageReference Include="FluentValidation"
+                      Version="12.0.0" />
+
+    <PackageReference Include="FluxionSharp"
+                      Version="2.0.0" />
+
+    <PackageReference Include="ImGui.NET"
+                      Version="1.91.6.1" />
+
+    <PackageReference Include="MathNet.Numerics"
+                      Version="5.0.0" />
+
+    <PackageReference Include="OpenTK"
+                      Version="4.9.4" />
+
+    <PackageReference Include="OpenTK.Windowing.Desktop"
+                      Version="4.9.4" />
+
+    <PackageReference Include="TorchSharp"
+                      Version="0.105.1" />
+
+    <PackageReference Include="xunit"
+                      Version="2.9.3" />
+
+    <PackageReference Include="xunit.abstractions"
+                      Version="2.0.3" />
+
+    <PackageReference Include="xunit.analyzers"
+                      Version="1.24.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>
+        runtime;
+        build;
+        native;
+        contentfiles;
+        analyzers;
+        buildtransitive
+      </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.core" Version="2.9.3" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <EditorConfigFiles Remove="C:\Users\sebas\source\repos\Fluxion\.editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="C:\Users\sebas\source\repos\Fluxion\.editorconfig" />
+    <PackageReference Include="xunit.core"
+                      Version="2.9.3" />
   </ItemGroup>
 
 </Project>

--- a/Fluxion.sln
+++ b/Fluxion.sln
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Diagrams", "Diagrams", "{71
 		Diagram2.codartis = Diagram2.codartis
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Desktop", "..\Desktop\Desktop.csproj", "{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Desktop", "Desktop\Desktop.csproj", "{C10A409E-CD3D-41ED-886D-957C2E784EDB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,18 +34,18 @@ Global
 		{46714FDB-CCEA-4291-9CEC-CF6321B84B4B}.Release|x64.Build.0 = Release|Any CPU
 		{46714FDB-CCEA-4291-9CEC-CF6321B84B4B}.Release|x86.ActiveCfg = Release|Any CPU
 		{46714FDB-CCEA-4291-9CEC-CF6321B84B4B}.Release|x86.Build.0 = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|x64.Build.0 = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Debug|x86.Build.0 = Debug|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|x64.ActiveCfg = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|x64.Build.0 = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|x86.ActiveCfg = Release|Any CPU
-		{BF3DA93C-D09A-4107-9C63-F1BF6B73ACC4}.Release|x86.Build.0 = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Debug|x86.Build.0 = Debug|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|x64.Build.0 = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{C10A409E-CD3D-41ED-886D-957C2E784EDB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added and configured the Fluxion WPF desktop interface, corrected the project references after reorganizing the repository, and fixed build conflicts caused by nested projects.

Changes include:

Added the Desktop WPF project to the Fluxion repository.
Configured WPF with net10.0-windows.
Added the OpenTK.GLWpfControl dependency.
Connected the Desktop project to Fluxion.csproj.
Initialized the OpenGL viewport so rendering can start correctly.
Excluded Desktop, bin, and obj folders from the root Fluxion compilation.
Fixed duplicate assembly attribute errors caused by nested generated files.
Updated the solution to use the new Desktop project location.
Added Git ignore rules for generated files and Visual Studio user settings.