### PR TITLE
Add Mathematical expression parser and automatic graphing

### DIFF
--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -4,11 +4,15 @@ using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Media;
+
+using Fluxion.src.Expressions;
 using Fluxion.src.Rendering.Draw;
 using Fluxion.src.Rendering.Visualize2D;
+
 using OpenTK.Graphics.OpenGL4;
 using OpenTK.Wpf;
 
+using Math = System.Math;
 using Matrix4 = OpenTK.Mathematics.Matrix4;
 using NumericsVector2 = System.Numerics.Vector2;
 using NumericsVector3 = System.Numerics.Vector3;
@@ -28,16 +32,12 @@ public partial class MainWindow : Window
     private double _yMinimum = -1.25;
     private double _yMaximum = 1.25;
 
+    private bool _isNumberLineMode;
+
     public MainWindow()
     {
         InitializeComponent();
 
-        /*
-         * This was the missing operation.
-         *
-         * GLWpfControl does not automatically create and start its
-         * OpenGL rendering context. Start() must be called explicitly.
-         */
         var settings = new GLWpfControlSettings
         {
             MajorVersion = 4,
@@ -52,22 +52,30 @@ public partial class MainWindow : Window
 
     private void Viewport_Render(TimeSpan delta)
     {
-        if (Viewport.ActualWidth <= 0 || Viewport.ActualHeight <= 0)
+        if (Viewport.ActualWidth <= 0 ||
+            Viewport.ActualHeight <= 0)
         {
             return;
         }
 
-        DpiScale dpi = VisualTreeHelper.GetDpi(Viewport);
+        DpiScale dpi =
+            VisualTreeHelper.GetDpi(Viewport);
 
         int width = Math.Max(
             1,
-            (int)(Viewport.ActualWidth * dpi.DpiScaleX));
+            (int)(Viewport.ActualWidth *
+                  dpi.DpiScaleX));
 
         int height = Math.Max(
             1,
-            (int)(Viewport.ActualHeight * dpi.DpiScaleY));
+            (int)(Viewport.ActualHeight *
+                  dpi.DpiScaleY));
 
-        GL.Viewport(0, 0, width, height);
+        GL.Viewport(
+            0,
+            0,
+            width,
+            height);
 
         GL.Disable(EnableCap.DepthTest);
 
@@ -82,11 +90,11 @@ public partial class MainWindow : Window
             ClearBufferMask.DepthBufferBit);
 
         /*
-         * CurveRenderer2D creates shaders, a VAO and a VBO.
-         * It must therefore be created only after Start() has created
-         * an active OpenGL context.
+         * Create the renderer only after the OpenGL context
+         * has been started.
          */
-        _curveRenderer ??= new CurveRenderer2D();
+        _curveRenderer ??=
+            new CurveRenderer2D();
 
         Matrix4 projection =
             Matrix4.CreateOrthographicOffCenter(
@@ -97,25 +105,40 @@ public partial class MainWindow : Window
                 -1.0f,
                 1.0f);
 
-        if (ShowGridBox.IsChecked == true)
+        /*
+         * Number-line mode does not use the normal graph grid.
+         */
+        if (!_isNumberLineMode &&
+            ShowGridBox.IsChecked == true)
         {
             foreach (Plot2D gridLine in _gridPlots)
             {
-                _curveRenderer.Draw(gridLine, projection);
+                _curveRenderer.Draw(
+                    gridLine,
+                    projection);
             }
         }
 
-        if (ShowAxesBox.IsChecked == true)
+        /*
+         * A number line must always draw its horizontal axis.
+         * For functions, the Show Axes checkbox controls it.
+         */
+        if (_isNumberLineMode ||
+            ShowAxesBox.IsChecked == true)
         {
             foreach (Plot2D axisLine in _axisPlots)
             {
-                _curveRenderer.Draw(axisLine, projection);
+                _curveRenderer.Draw(
+                    axisLine,
+                    projection);
             }
         }
 
         if (_functionPlot is not null)
         {
-            _curveRenderer.Draw(_functionPlot, projection);
+            _curveRenderer.Draw(
+                _functionPlot,
+                projection);
         }
     }
 
@@ -134,6 +157,8 @@ public partial class MainWindow : Window
 
         _gridPlots.Clear();
         _axisPlots.Clear();
+
+        _isNumberLineMode = false;
 
         StatusText.Text = "Graph cleared";
 
@@ -167,19 +192,70 @@ public partial class MainWindow : Window
     {
         try
         {
+            /*
+             * Index 0 is currently the supported automatic
+             * scalar-or-2D mode.
+             */
             if (GraphTypeBox.SelectedIndex != 0)
             {
                 throw new NotSupportedException(
-                    "The WPF viewport is currently connected to the 2D renderer. Select 2D Function.");
+                    "3D surfaces are not connected yet. " +
+                    "Select the first graph type option.");
             }
 
-            if (!TryParseNumber(XMinBox.Text, out double xMinimum))
+            CompiledExpression expression =
+                ExpressionEngine.Compile(
+                    FunctionBox.Text);
+
+            /*
+             * An expression without x is a scalar calculation.
+             *
+             * Examples:
+             * 1
+             * 2 + 3 * 4
+             * pi / 2
+             * sqrt(16)
+             */
+            if (!expression.ContainsVariable)
+            {
+                double result =
+                    expression.Evaluate();
+
+                if (!double.IsFinite(result))
+                {
+                    throw new ArithmeticException(
+                        "The expression did not produce " +
+                        "a finite real number.");
+                }
+
+                BuildNumberLine(result);
+
+                StatusText.Text =
+                    $"{FunctionBox.Text.Trim()} = " +
+                    result.ToString(
+                        "G12",
+                        CultureInfo.InvariantCulture);
+
+                Viewport.InvalidateVisual();
+                return;
+            }
+
+            /*
+             * An expression containing x becomes a 2D function.
+             */
+            _isNumberLineMode = false;
+
+            if (!TryParseNumber(
+                    XMinBox.Text,
+                    out double xMinimum))
             {
                 throw new FormatException(
                     "X minimum is not a valid number.");
             }
 
-            if (!TryParseNumber(XMaxBox.Text, out double xMaximum))
+            if (!TryParseNumber(
+                    XMaxBox.Text,
+                    out double xMaximum))
             {
                 throw new FormatException(
                     "X maximum is not a valid number.");
@@ -188,7 +264,8 @@ public partial class MainWindow : Window
             if (xMinimum >= xMaximum)
             {
                 throw new ArgumentException(
-                    "X minimum must be smaller than X maximum.");
+                    "X minimum must be smaller " +
+                    "than X maximum.");
             }
 
             _xMinimum = xMinimum;
@@ -198,12 +275,9 @@ public partial class MainWindow : Window
                 25,
                 (int)ResolutionSlider.Value);
 
-            Func<double, double> function =
-                ParseFunction(FunctionBox.Text);
-
             _functionPlot =
                 Plot2DFactory.Function(
-                    function,
+                    expression.ToFunction(),
                     _xMinimum,
                     _xMaximum,
                     samples,
@@ -222,20 +296,135 @@ public partial class MainWindow : Window
             BuildGridAndAxes();
 
             StatusText.Text =
-                $"Plotting {FunctionBox.Text.Trim()}";
+                $"Plotting y = {expression.Source}";
 
             Viewport.InvalidateVisual();
         }
         catch (Exception exception)
         {
-            StatusText.Text = exception.Message;
+            StatusText.Text =
+                exception.Message;
 
             MessageBox.Show(
                 exception.Message,
-                "Unable to plot function",
+                "Unable to process expression",
                 MessageBoxButton.OK,
                 MessageBoxImage.Warning);
         }
+    }
+
+    private void BuildNumberLine(double value)
+    {
+        _isNumberLineMode = true;
+
+        /*
+         * Keep both zero and the result visible.
+         */
+        double padding = Math.Max(
+            1.0,
+            Math.Abs(value) * 0.20);
+
+        if (Math.Abs(value) < 0.000001)
+        {
+            _xMinimum = -5;
+            _xMaximum = 5;
+        }
+        else
+        {
+            _xMinimum =
+                Math.Min(0.0, value) - padding;
+
+            _xMaximum =
+                Math.Max(0.0, value) + padding;
+        }
+
+        _yMinimum = -1.0;
+        _yMaximum = 1.0;
+
+        _gridPlots.Clear();
+        _axisPlots.Clear();
+
+        var axisColor =
+            new NumericsVector3(
+                0.85f,
+                0.85f,
+                0.85f);
+
+        /*
+         * Main horizontal number line.
+         */
+        _axisPlots.Add(
+            CreateLine(
+                (float)_xMinimum,
+                0.0f,
+                (float)_xMaximum,
+                0.0f,
+                axisColor,
+                2.0f));
+
+        double tickStep =
+            CalculateNiceStep(
+                _xMinimum,
+                _xMaximum);
+
+        double firstTick =
+            Math.Ceiling(
+                _xMinimum / tickStep) *
+            tickStep;
+
+        /*
+         * Tick marks along the number line.
+         */
+        for (double tick = firstTick;
+             tick <= _xMaximum + 0.000001;
+             tick += tickStep)
+        {
+            _axisPlots.Add(
+                CreateLine(
+                    (float)tick,
+                    -0.08f,
+                    (float)tick,
+                    0.08f,
+                    axisColor,
+                    1.5f));
+        }
+
+        /*
+         * Make zero slightly larger.
+         */
+        if (_xMinimum <= 0 &&
+            _xMaximum >= 0)
+        {
+            _axisPlots.Add(
+                CreateLine(
+                    0.0f,
+                    -0.14f,
+                    0.0f,
+                    0.14f,
+                    axisColor,
+                    2.0f));
+        }
+
+        /*
+         * Draw the evaluated result as a point.
+         */
+        _functionPlot =
+            new Plot2D(
+                new PlotStyle
+                {
+                    Lines = false,
+                    Points = true,
+                    Width = 12.0f,
+                    Rgb = new NumericsVector3(
+                        0.20f,
+                        0.80f,
+                        1.00f)
+                });
+
+        _functionPlot.Points.Add(
+            new NumericsVector2(
+                (float)value,
+                0.0f));
     }
 
     private void CalculateYBounds()
@@ -247,45 +436,61 @@ public partial class MainWindow : Window
             return;
         }
 
-        double[] finiteValues = _functionPlot.Points
-            .Select(point => (double)point.Y)
-            .Where(value =>
-                double.IsFinite(value) &&
-                Math.Abs(value) < 1_000_000)
-            .ToArray();
+        double[] finiteValues =
+            _functionPlot.Points
+                .Select(point =>
+                    (double)point.Y)
+                .Where(value =>
+                    double.IsFinite(value) &&
+                    Math.Abs(value) < 1_000_000)
+                .ToArray();
 
         if (finiteValues.Length == 0)
         {
-            _yMinimum = -1;
-            _yMaximum = 1;
-            return;
+            throw new ArithmeticException(
+                "The expression did not produce any " +
+                "finite real values in the selected range.");
         }
 
-        double minimum = finiteValues.Min();
-        double maximum = finiteValues.Max();
+        double minimum =
+            finiteValues.Min();
 
-        double range = maximum - minimum;
+        double maximum =
+            finiteValues.Max();
+
+        double range =
+            maximum - minimum;
 
         if (range < 0.000001)
         {
-            range = 2;
+            double center = minimum;
+
+            _yMinimum = center - 1.0;
+            _yMaximum = center + 1.0;
+            return;
         }
 
-        double padding = range * 0.15;
+        double padding =
+            range * 0.15;
 
-        _yMinimum = minimum - padding;
-        _yMaximum = maximum + padding;
+        _yMinimum =
+            minimum - padding;
+
+        _yMaximum =
+            maximum + padding;
 
         /*
-         * Keep zero visible when the function is close to zero,
-         * which makes functions such as sin(x) easier to read.
+         * Keep zero visible when it is reasonably
+         * close to the function's range.
          */
-        if (_yMinimum > 0 && _yMinimum < range)
+        if (_yMinimum > 0 &&
+            _yMinimum < range)
         {
             _yMinimum = 0;
         }
 
-        if (_yMaximum < 0 && Math.Abs(_yMaximum) < range)
+        if (_yMaximum < 0 &&
+            Math.Abs(_yMaximum) < range)
         {
             _yMaximum = 0;
         }
@@ -297,13 +502,19 @@ public partial class MainWindow : Window
         _axisPlots.Clear();
 
         double xStep =
-            CalculateNiceStep(_xMinimum, _xMaximum);
+            CalculateNiceStep(
+                _xMinimum,
+                _xMaximum);
 
         double yStep =
-            CalculateNiceStep(_yMinimum, _yMaximum);
+            CalculateNiceStep(
+                _yMinimum,
+                _yMaximum);
 
         double firstX =
-            Math.Ceiling(_xMinimum / xStep) * xStep;
+            Math.Ceiling(
+                _xMinimum / xStep) *
+            xStep;
 
         for (double x = firstX;
              x <= _xMaximum + 0.000001;
@@ -323,7 +534,9 @@ public partial class MainWindow : Window
         }
 
         double firstY =
-            Math.Ceiling(_yMinimum / yStep) * yStep;
+            Math.Ceiling(
+                _yMinimum / yStep) *
+            yStep;
 
         for (double y = firstY;
              y <= _yMaximum + 0.000001;
@@ -342,7 +555,11 @@ public partial class MainWindow : Window
                     1.0f));
         }
 
-        if (_xMinimum <= 0 && _xMaximum >= 0)
+        /*
+         * Y axis.
+         */
+        if (_xMinimum <= 0 &&
+            _xMaximum >= 0)
         {
             _axisPlots.Add(
                 CreateLine(
@@ -357,7 +574,11 @@ public partial class MainWindow : Window
                     2.0f));
         }
 
-        if (_yMinimum <= 0 && _yMaximum >= 0)
+        /*
+         * X axis.
+         */
+        if (_yMinimum <= 0 &&
+            _yMaximum >= 0)
         {
             _axisPlots.Add(
                 CreateLine(
@@ -381,90 +602,58 @@ public partial class MainWindow : Window
         NumericsVector3 color,
         float width)
     {
-        var plot = new Plot2D(
-            new PlotStyle
-            {
-                Lines = true,
-                Points = false,
-                Width = width,
-                Rgb = color
-            });
+        var plot =
+            new Plot2D(
+                new PlotStyle
+                {
+                    Lines = true,
+                    Points = false,
+                    Width = width,
+                    Rgb = color
+                });
 
         plot.Points.Add(
-            new NumericsVector2(x1, y1));
+            new NumericsVector2(
+                x1,
+                y1));
 
         plot.Points.Add(
-            new NumericsVector2(x2, y2));
+            new NumericsVector2(
+                x2,
+                y2));
 
         return plot;
-    }
-
-    private static Func<double, double> ParseFunction(
-        string expression)
-    {
-        string normalized = expression
-            .Trim()
-            .ToLowerInvariant()
-            .Replace(" ", string.Empty);
-
-        return normalized switch
-        {
-            "sin(x)" or "sin" =>
-                System.Math.Sin,
-
-            "cos(x)" or "cos" =>
-                System.Math.Cos,
-
-            "tan(x)" or "tan" =>
-                System.Math.Tan,
-
-            "x" =>
-                x => x,
-
-            "x^2" or "x*x" =>
-                x => x * x,
-
-            "x^3" or "x*x*x" =>
-                x => x * x * x,
-
-            "abs(x)" =>
-                System.Math.Abs,
-
-            "sqrt(x)" =>
-                System.Math.Sqrt,
-
-            "1/x" =>
-                x => 1.0 / x,
-
-            _ => throw new NotSupportedException(
-                "Supported functions: sin(x), cos(x), tan(x), x, x^2, x^3, abs(x), sqrt(x), and 1/x.")
-        };
     }
 
     private static double CalculateNiceStep(
         double minimum,
         double maximum)
     {
-        double span =
-            Math.Max(0.000001, maximum - minimum);
+        double span = Math.Max(
+            0.000001,
+            maximum - minimum);
 
-        double roughStep = span / 10.0;
+        double roughStep =
+            span / 10.0;
 
         double magnitude =
             Math.Pow(
                 10,
                 Math.Floor(
-                    Math.Log10(roughStep)));
+                    Math.Log10(
+                        roughStep)));
 
-        double normalized = roughStep / magnitude;
+        double normalized =
+            roughStep / magnitude;
 
-        double niceValue = normalized switch
-        {
-            < 1.5 => 1,
-            < 3.0 => 2,
-            < 7.0 => 5,
-            _ => 10
-        };
+        double niceValue =
+            normalized switch
+            {
+                < 1.5 => 1,
+                < 3.0 => 2,
+                < 7.0 => 5,
+                _ => 10
+            };
 
         return niceValue * magnitude;
     }

--- a/Fluxion.csproj
+++ b/Fluxion.csproj
@@ -47,38 +47,27 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions"
-                      Version="8.6.0" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
 
-    <PackageReference Include="FluentValidation"
-                      Version="12.0.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
 
-    <PackageReference Include="FluxionSharp"
-                      Version="2.0.0" />
+    <PackageReference Include="FluxionSharp" Version="2.0.0" />
 
-    <PackageReference Include="ImGui.NET"
-                      Version="1.91.6.1" />
+    <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
 
-    <PackageReference Include="MathNet.Numerics"
-                      Version="5.0.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
 
-    <PackageReference Include="OpenTK"
-                      Version="4.9.4" />
+    <PackageReference Include="OpenTK" Version="4.9.4" />
 
-    <PackageReference Include="OpenTK.Windowing.Desktop"
-                      Version="4.9.4" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.4" />
 
-    <PackageReference Include="TorchSharp"
-                      Version="0.105.1" />
+    <PackageReference Include="TorchSharp" Version="0.105.1" />
 
-    <PackageReference Include="xunit"
-                      Version="2.9.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
 
-    <PackageReference Include="xunit.abstractions"
-                      Version="2.0.3" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
 
-    <PackageReference Include="xunit.analyzers"
-                      Version="1.24.0">
+    <PackageReference Include="xunit.analyzers" Version="1.24.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
         runtime;
@@ -90,8 +79,11 @@
       </IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="xunit.core"
-                      Version="2.9.3" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="src\Expressions\" />
   </ItemGroup>
 
 </Project>

--- a/src/Expressions/ExpressionEngine.cs
+++ b/src/Expressions/ExpressionEngine.cs
@@ -1,0 +1,852 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Fluxion.src.Expressions;
+
+/// <summary>
+/// Entry point for compiling user-entered mathematical expressions.
+/// </summary>
+public static class ExpressionEngine
+{
+    public static CompiledExpression Compile(string expression)
+    {
+        string normalized = NormalizeExpression(expression);
+
+        var lexer = new ExpressionLexer(normalized);
+        IReadOnlyList<ExpressionToken> tokens = lexer.Tokenize();
+
+        var parser = new ExpressionParser(tokens);
+        ExpressionNode root = parser.Parse();
+
+        return new CompiledExpression(normalized, root);
+    }
+
+    private static string NormalizeExpression(string expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            throw new ExpressionParseException(
+                "Enter a mathematical expression",
+                0);
+        }
+
+        string normalized = expression
+            .Trim()
+            .Replace("−", "-")
+            .Replace("–", "-")
+            .Replace("×", "*")
+            .Replace("·", "*")
+            .Replace("÷", "/")
+            .Replace("π", "pi")
+            .Replace("²", "^2")
+            .Replace("³", "^3");
+
+        int equalsIndex = normalized.IndexOf('=');
+
+        if (equalsIndex < 0)
+        {
+            return normalized;
+        }
+
+        if (normalized.IndexOf('=', equalsIndex + 1) >= 0)
+        {
+            throw new ExpressionParseException(
+                "Step 1 supports only one assignment symbol",
+                equalsIndex);
+        }
+
+        string leftSide = normalized[..equalsIndex]
+            .Trim()
+            .ToLowerInvariant();
+
+        string rightSide = normalized[(equalsIndex + 1)..]
+            .Trim();
+
+        if (!IsSupportedAssignment(leftSide))
+        {
+            throw new ExpressionParseException(
+                "Use an expression, y = expression, or f(x) = expression",
+                0);
+        }
+
+        if (rightSide.Length == 0)
+        {
+            throw new ExpressionParseException(
+                "An expression is required after '='",
+                equalsIndex + 1);
+        }
+
+        return rightSide;
+    }
+
+    private static bool IsSupportedAssignment(string leftSide)
+    {
+        if (leftSide == "y")
+        {
+            return true;
+        }
+
+        int openParenthesis = leftSide.IndexOf('(');
+        int closeParenthesis = leftSide.LastIndexOf(')');
+
+        if (openParenthesis <= 0 ||
+            closeParenthesis != leftSide.Length - 1)
+        {
+            return false;
+        }
+
+        string functionName = leftSide[..openParenthesis].Trim();
+        string parameter = leftSide[(openParenthesis + 1)..closeParenthesis].Trim();
+
+        if (parameter != "x" || functionName.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (char character in functionName)
+        {
+            if (!char.IsLetter(character) && character != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// A parsed expression that can be evaluated repeatedly.
+/// </summary>
+public sealed class CompiledExpression
+{
+    private readonly ExpressionNode _root;
+
+    internal CompiledExpression(string source, ExpressionNode root)
+    {
+        Source = source;
+        _root = root;
+    }
+
+    public string Source { get; }
+
+    public bool ContainsVariable => _root.ContainsVariable;
+
+    public double Evaluate(double x = 0.0)
+    {
+        return _root.Evaluate(x);
+    }
+
+    public Func<double, double> ToFunction()
+    {
+        return Evaluate;
+    }
+}
+
+/// <summary>
+/// A parsing error with the location of the invalid input.
+/// </summary>
+public sealed class ExpressionParseException : Exception
+{
+    public ExpressionParseException(string message, int position)
+        : base($"{message} at position {position + 1}.")
+    {
+        Position = position;
+    }
+
+    public int Position { get; }
+}
+
+internal enum ExpressionTokenKind
+{
+    Number,
+    Identifier,
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    Power,
+    LeftParenthesis,
+    RightParenthesis,
+    Comma,
+    End
+}
+
+internal readonly record struct ExpressionToken(
+    ExpressionTokenKind Kind,
+    string Text,
+    double Number,
+    int Position);
+
+internal sealed class ExpressionLexer
+{
+    private readonly string _text;
+    private readonly List<ExpressionToken> _tokens = new();
+    private int _position;
+
+    public ExpressionLexer(string text)
+    {
+        _text = text;
+    }
+
+    public IReadOnlyList<ExpressionToken> Tokenize()
+    {
+        while (!IsAtEnd)
+        {
+            char current = Current;
+
+            if (char.IsWhiteSpace(current))
+            {
+                _position++;
+                continue;
+            }
+
+            if (char.IsDigit(current) ||
+                (current == '.' && char.IsDigit(Peek(1))))
+            {
+                ReadNumber();
+                continue;
+            }
+
+            if (char.IsLetter(current) || current == '_')
+            {
+                ReadIdentifier();
+                continue;
+            }
+
+            int tokenPosition = _position;
+            _position++;
+
+            ExpressionTokenKind kind = current switch
+            {
+                '+' => ExpressionTokenKind.Plus,
+                '-' => ExpressionTokenKind.Minus,
+                '*' => ExpressionTokenKind.Multiply,
+                '/' => ExpressionTokenKind.Divide,
+                '^' => ExpressionTokenKind.Power,
+                '(' => ExpressionTokenKind.LeftParenthesis,
+                ')' => ExpressionTokenKind.RightParenthesis,
+                ',' => ExpressionTokenKind.Comma,
+                _ => throw new ExpressionParseException(
+                    $"Unexpected character '{current}'",
+                    tokenPosition)
+            };
+
+            AddSimpleToken(kind, current.ToString(), tokenPosition);
+        }
+
+        _tokens.Add(new ExpressionToken(
+            ExpressionTokenKind.End,
+            string.Empty,
+            0.0,
+            _position));
+
+        return _tokens;
+    }
+
+    private bool IsAtEnd => _position >= _text.Length;
+
+    private char Current => IsAtEnd ? '\0' : _text[_position];
+
+    private char Peek(int distance)
+    {
+        int index = _position + distance;
+        return index >= _text.Length ? '\0' : _text[index];
+    }
+
+    private void ReadNumber()
+    {
+        int start = _position;
+
+        while (char.IsDigit(Current))
+        {
+            _position++;
+        }
+
+        if (Current == '.')
+        {
+            _position++;
+
+            while (char.IsDigit(Current))
+            {
+                _position++;
+            }
+        }
+
+        if (Current is 'e' or 'E')
+        {
+            int exponentMarker = _position;
+            int cursor = _position + 1;
+
+            if (cursor < _text.Length &&
+                _text[cursor] is '+' or '-')
+            {
+                cursor++;
+            }
+
+            int digitStart = cursor;
+
+            while (cursor < _text.Length &&
+                   char.IsDigit(_text[cursor]))
+            {
+                cursor++;
+            }
+
+            _position = cursor > digitStart
+                ? cursor
+                : exponentMarker;
+        }
+
+        string numberText = _text[start.._position];
+
+        if (!double.TryParse(
+                numberText,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out double value))
+        {
+            throw new ExpressionParseException(
+                $"'{numberText}' is not a valid number",
+                start);
+        }
+
+        _tokens.Add(new ExpressionToken(
+            ExpressionTokenKind.Number,
+            numberText,
+            value,
+            start));
+    }
+
+    private void ReadIdentifier()
+    {
+        int start = _position;
+
+        while (char.IsLetterOrDigit(Current) || Current == '_')
+        {
+            _position++;
+        }
+
+        string identifier = _text[start.._position]
+            .ToLowerInvariant();
+
+        _tokens.Add(new ExpressionToken(
+            ExpressionTokenKind.Identifier,
+            identifier,
+            0.0,
+            start));
+    }
+
+    private void AddSimpleToken(
+        ExpressionTokenKind kind,
+        string text,
+        int position)
+    {
+        _tokens.Add(new ExpressionToken(
+            kind,
+            text,
+            0.0,
+            position));
+    }
+}
+
+internal sealed class ExpressionParser
+{
+    private readonly IReadOnlyList<ExpressionToken> _tokens;
+    private int _current;
+
+    public ExpressionParser(IReadOnlyList<ExpressionToken> tokens)
+    {
+        _tokens = tokens;
+    }
+
+    public ExpressionNode Parse()
+    {
+        ExpressionNode expression = ParseAdditionAndSubtraction();
+
+        if (Current.Kind != ExpressionTokenKind.End)
+        {
+            throw new ExpressionParseException(
+                $"Unexpected token '{Current.Text}'",
+                Current.Position);
+        }
+
+        return expression;
+    }
+
+    private ExpressionNode ParseAdditionAndSubtraction()
+    {
+        ExpressionNode left = ParseMultiplicationAndDivision();
+
+        while (true)
+        {
+            if (Match(ExpressionTokenKind.Plus))
+            {
+                left = new BinaryExpressionNode(
+                    BinaryOperator.Add,
+                    left,
+                    ParseMultiplicationAndDivision());
+                continue;
+            }
+
+            if (Match(ExpressionTokenKind.Minus))
+            {
+                left = new BinaryExpressionNode(
+                    BinaryOperator.Subtract,
+                    left,
+                    ParseMultiplicationAndDivision());
+                continue;
+            }
+
+            return left;
+        }
+    }
+
+    private ExpressionNode ParseMultiplicationAndDivision()
+    {
+        ExpressionNode left = ParseUnary();
+
+        while (true)
+        {
+            if (Match(ExpressionTokenKind.Multiply))
+            {
+                left = new BinaryExpressionNode(
+                    BinaryOperator.Multiply,
+                    left,
+                    ParseUnary());
+                continue;
+            }
+
+            if (Match(ExpressionTokenKind.Divide))
+            {
+                left = new BinaryExpressionNode(
+                    BinaryOperator.Divide,
+                    left,
+                    ParseUnary());
+                continue;
+            }
+
+            if (CanStartImplicitFactor(Current.Kind))
+            {
+                left = new BinaryExpressionNode(
+                    BinaryOperator.Multiply,
+                    left,
+                    ParseUnary());
+                continue;
+            }
+
+            return left;
+        }
+    }
+
+    private ExpressionNode ParseUnary()
+    {
+        if (Match(ExpressionTokenKind.Plus))
+        {
+            return new UnaryExpressionNode(
+                UnaryOperator.Positive,
+                ParseUnary());
+        }
+
+        if (Match(ExpressionTokenKind.Minus))
+        {
+            return new UnaryExpressionNode(
+                UnaryOperator.Negative,
+                ParseUnary());
+        }
+
+        return ParsePower();
+    }
+
+    private ExpressionNode ParsePower()
+    {
+        ExpressionNode left = ParsePrimary();
+
+        if (Match(ExpressionTokenKind.Power))
+        {
+            return new BinaryExpressionNode(
+                BinaryOperator.Power,
+                left,
+                ParseUnary());
+        }
+
+        return left;
+    }
+
+    private ExpressionNode ParsePrimary()
+    {
+        if (Match(ExpressionTokenKind.Number))
+        {
+            return new NumberExpressionNode(Previous.Number);
+        }
+
+        if (Match(ExpressionTokenKind.Identifier))
+        {
+            ExpressionToken identifier = Previous;
+
+            if (Match(ExpressionTokenKind.LeftParenthesis))
+            {
+                return ParseFunctionCall(identifier);
+            }
+
+            return ParseIdentifier(identifier);
+        }
+
+        if (Match(ExpressionTokenKind.LeftParenthesis))
+        {
+            int openingPosition = Previous.Position;
+            ExpressionNode inner = ParseAdditionAndSubtraction();
+
+            if (!Match(ExpressionTokenKind.RightParenthesis))
+            {
+                throw new ExpressionParseException(
+                    "Expected ')'",
+                    openingPosition);
+            }
+
+            return inner;
+        }
+
+        if (Current.Kind == ExpressionTokenKind.End)
+        {
+            throw new ExpressionParseException(
+                "The expression ended unexpectedly",
+                Current.Position);
+        }
+
+        throw new ExpressionParseException(
+            $"Expected a number, variable, function, or '(' instead of '{Current.Text}'",
+            Current.Position);
+    }
+
+    private ExpressionNode ParseFunctionCall(ExpressionToken identifier)
+    {
+        var arguments = new List<ExpressionNode>();
+
+        if (!Check(ExpressionTokenKind.RightParenthesis))
+        {
+            do
+            {
+                arguments.Add(ParseAdditionAndSubtraction());
+            }
+            while (Match(ExpressionTokenKind.Comma));
+        }
+
+        if (!Match(ExpressionTokenKind.RightParenthesis))
+        {
+            throw new ExpressionParseException(
+                $"Expected ')' after function '{identifier.Text}'",
+                identifier.Position);
+        }
+
+        FunctionCatalog.Validate(
+            identifier.Text,
+            arguments.Count,
+            identifier.Position);
+
+        return new FunctionExpressionNode(
+            identifier.Text,
+            arguments);
+    }
+
+    private static ExpressionNode ParseIdentifier(ExpressionToken identifier)
+    {
+        return identifier.Text switch
+        {
+            "x" => new VariableExpressionNode(),
+            "pi" => new NumberExpressionNode(Math.PI),
+            "e" => new NumberExpressionNode(Math.E),
+            "tau" => new NumberExpressionNode(Math.Tau),
+
+            _ when FunctionCatalog.IsKnown(identifier.Text) =>
+                throw new ExpressionParseException(
+                    $"Function '{identifier.Text}' requires parentheses, for example {identifier.Text}(x)",
+                    identifier.Position),
+
+            _ => throw new ExpressionParseException(
+                $"Unknown identifier '{identifier.Text}'. Step 1 supports the variable x",
+                identifier.Position)
+        };
+    }
+
+    private static bool CanStartImplicitFactor(ExpressionTokenKind kind)
+    {
+        return kind is
+            ExpressionTokenKind.Number or
+            ExpressionTokenKind.Identifier or
+            ExpressionTokenKind.LeftParenthesis;
+    }
+
+    private ExpressionToken Current => _tokens[_current];
+    private ExpressionToken Previous => _tokens[_current - 1];
+
+    private bool Check(ExpressionTokenKind kind)
+    {
+        return Current.Kind == kind;
+    }
+
+    private bool Match(ExpressionTokenKind kind)
+    {
+        if (!Check(kind))
+        {
+            return false;
+        }
+
+        _current++;
+        return true;
+    }
+}
+
+internal abstract class ExpressionNode
+{
+    public abstract bool ContainsVariable { get; }
+    public abstract double Evaluate(double x);
+}
+
+internal sealed class NumberExpressionNode : ExpressionNode
+{
+    private readonly double _value;
+
+    public NumberExpressionNode(double value)
+    {
+        _value = value;
+    }
+
+    public override bool ContainsVariable => false;
+
+    public override double Evaluate(double x)
+    {
+        return _value;
+    }
+}
+
+internal sealed class VariableExpressionNode : ExpressionNode
+{
+    public override bool ContainsVariable => true;
+
+    public override double Evaluate(double x)
+    {
+        return x;
+    }
+}
+
+internal enum UnaryOperator
+{
+    Positive,
+    Negative
+}
+
+internal sealed class UnaryExpressionNode : ExpressionNode
+{
+    private readonly UnaryOperator _operator;
+    private readonly ExpressionNode _operand;
+
+    public UnaryExpressionNode(
+        UnaryOperator @operator,
+        ExpressionNode operand)
+    {
+        _operator = @operator;
+        _operand = operand;
+    }
+
+    public override bool ContainsVariable => _operand.ContainsVariable;
+
+    public override double Evaluate(double x)
+    {
+        double value = _operand.Evaluate(x);
+
+        return _operator switch
+        {
+            UnaryOperator.Positive => value,
+            UnaryOperator.Negative => -value,
+            _ => throw new InvalidOperationException("Unknown unary operator.")
+        };
+    }
+}
+
+internal enum BinaryOperator
+{
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Power
+}
+
+internal sealed class BinaryExpressionNode : ExpressionNode
+{
+    private readonly BinaryOperator _operator;
+    private readonly ExpressionNode _left;
+    private readonly ExpressionNode _right;
+
+    public BinaryExpressionNode(
+        BinaryOperator @operator,
+        ExpressionNode left,
+        ExpressionNode right)
+    {
+        _operator = @operator;
+        _left = left;
+        _right = right;
+    }
+
+    public override bool ContainsVariable =>
+        _left.ContainsVariable || _right.ContainsVariable;
+
+    public override double Evaluate(double x)
+    {
+        double leftValue = _left.Evaluate(x);
+        double rightValue = _right.Evaluate(x);
+
+        return _operator switch
+        {
+            BinaryOperator.Add => leftValue + rightValue,
+            BinaryOperator.Subtract => leftValue - rightValue,
+            BinaryOperator.Multiply => leftValue * rightValue,
+            BinaryOperator.Divide => leftValue / rightValue,
+            BinaryOperator.Power => Math.Pow(leftValue, rightValue),
+            _ => throw new InvalidOperationException("Unknown binary operator.")
+        };
+    }
+}
+
+internal sealed class FunctionExpressionNode : ExpressionNode
+{
+    private readonly string _name;
+    private readonly IReadOnlyList<ExpressionNode> _arguments;
+
+    public FunctionExpressionNode(
+        string name,
+        IReadOnlyList<ExpressionNode> arguments)
+    {
+        _name = name;
+        _arguments = arguments;
+    }
+
+    public override bool ContainsVariable
+    {
+        get
+        {
+            foreach (ExpressionNode argument in _arguments)
+            {
+                if (argument.ContainsVariable)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public override double Evaluate(double x)
+    {
+        var values = new double[_arguments.Count];
+
+        for (int index = 0; index < _arguments.Count; index++)
+        {
+            values[index] = _arguments[index].Evaluate(x);
+        }
+
+        return FunctionCatalog.Evaluate(_name, values);
+    }
+}
+
+internal static class FunctionCatalog
+{
+    private static readonly HashSet<string> KnownFunctions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "sin",
+            "cos",
+            "tan",
+            "asin",
+            "acos",
+            "atan",
+            "sqrt",
+            "abs",
+            "exp",
+            "ln",
+            "log",
+            "floor",
+            "ceil",
+            "round",
+            "sign",
+            "min",
+            "max",
+            "pow",
+            "clamp"
+        };
+
+    public static bool IsKnown(string name)
+    {
+        return KnownFunctions.Contains(name);
+    }
+
+    public static void Validate(
+        string name,
+        int argumentCount,
+        int position)
+    {
+        if (!IsKnown(name))
+        {
+            throw new ExpressionParseException(
+                $"Unknown function '{name}'",
+                position);
+        }
+
+        bool valid = name switch
+        {
+            "min" or "max" or "pow" => argumentCount == 2,
+            "clamp" => argumentCount == 3,
+            "log" => argumentCount is 1 or 2,
+            _ => argumentCount == 1
+        };
+
+        if (valid)
+        {
+            return;
+        }
+
+        string expected = name switch
+        {
+            "min" or "max" or "pow" => "2 arguments",
+            "clamp" => "3 arguments",
+            "log" => "1 or 2 arguments",
+            _ => "1 argument"
+        };
+
+        throw new ExpressionParseException(
+            $"Function '{name}' expects {expected}, but received {argumentCount}",
+            position);
+    }
+
+    public static double Evaluate(
+        string name,
+        IReadOnlyList<double> arguments)
+    {
+        return name switch
+        {
+            "sin" => Math.Sin(arguments[0]),
+            "cos" => Math.Cos(arguments[0]),
+            "tan" => Math.Tan(arguments[0]),
+            "asin" => Math.Asin(arguments[0]),
+            "acos" => Math.Acos(arguments[0]),
+            "atan" => Math.Atan(arguments[0]),
+            "sqrt" => Math.Sqrt(arguments[0]),
+            "abs" => Math.Abs(arguments[0]),
+            "exp" => Math.Exp(arguments[0]),
+            "ln" => Math.Log(arguments[0]),
+            "log" when arguments.Count == 1 => Math.Log10(arguments[0]),
+            "log" => Math.Log(arguments[0], arguments[1]),
+            "floor" => Math.Floor(arguments[0]),
+            "ceil" => Math.Ceiling(arguments[0]),
+            "round" => Math.Round(arguments[0]),
+            "sign" => Math.Sign(arguments[0]),
+            "min" => Math.Min(arguments[0], arguments[1]),
+            "max" => Math.Max(arguments[0], arguments[1]),
+            "pow" => Math.Pow(arguments[0], arguments[1]),
+            "clamp" => Math.Clamp(arguments[0], arguments[1], arguments[2]),
+            _ => throw new InvalidOperationException($"Unknown function '{name}'.")
+        };
+    }
+}


### PR DESCRIPTION
This pull request upgrades Fluxion from a small hard-coded function selector into a real mathematical expression engine.

Changes
Added tokenization and parsing for user-entered mathematical expressions.
Added a reusable expression syntax tree and evaluator.
Added support for arithmetic operators, parentheses, powers, constants, and common functions.
Added implicit multiplication support, including:
2x
3(x + 1)
2sin(x)
(x + 1)(x - 1)
Added support for inputs such as:
2 + 3 * 4
x^2 - 3x
sin(x) + cos(x)
y = 2sin(x)
f(x) = exp(-x^2)
Automatically detects whether the input is:
A scalar calculation, displayed on a number line.
A function containing x, displayed as a 2D graph.
Replaced the previous hard-coded ParseFunction switch.
Improved error messages for invalid expressions and unsupported syntax.
Updated the desktop interface to work with general mathematical expressions.
Supported features
Numbers and decimals
Variable x
+, -, *, /, and ^
Parentheses
Constants: pi, e, and tau
Functions including sin, cos, tan, sqrt, abs, exp, ln, log, min, max, pow, and clamp