### PR TITLE
Connect 3D surface graphing to WPF viewport

### DIFF
--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -1,31 +1,59 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 
 using Fluxion.src.Expressions;
+using Fluxion.src.Numerics.Functions3D;
+using Fluxion.src.Plotting.Sampling;
+using Fluxion.src.Rendering.Camera;
 using Fluxion.src.Rendering.Draw;
 using Fluxion.src.Rendering.Visualize2D;
+using Fluxion.src.Rendering.Visualize3D;
 
 using OpenTK.Graphics.OpenGL4;
+using OpenTK.Mathematics;
 using OpenTK.Wpf;
 
 using Math = System.Math;
-using Matrix4 = OpenTK.Mathematics.Matrix4;
 using NumericsVector2 = System.Numerics.Vector2;
 using NumericsVector3 = System.Numerics.Vector3;
+using WpfPoint = System.Windows.Point;
 
 namespace Fluxion.Desktop;
 
 public partial class MainWindow : Window
 {
-    private CurveRenderer2D? _curveRenderer;
-    private Plot2D? _functionPlot;
+    private enum GraphRenderMode
+    {
+        TwoD,
+        ThreeD
+    }
 
+    private CurveRenderer2D? _curveRenderer;
+
+    private readonly List<Plot2D> _functionPlots = new();
     private readonly List<Plot2D> _gridPlots = new();
     private readonly List<Plot2D> _axisPlots = new();
+
+    private SurfaceRenderer? _surfaceRenderer;
+    private Axis3DRenderer? _axis3DRenderer;
+    private Mesh3D? _surfaceMesh;
+
+    private readonly OrbitCamera _orbitCamera = new();
+
+    private bool _surfaceUploadPending;
+    private int _requestedAxisExtent = 10;
+    private int _activeAxisExtent;
+
+    private WpfPoint _lastMousePosition;
+    private bool _isOrbiting;
+
+    private GraphRenderMode _renderMode =
+        GraphRenderMode.TwoD;
 
     private double _xMinimum = -10;
     private double _xMaximum = 10;
@@ -38,19 +66,36 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
-        var settings = new GLWpfControlSettings
-        {
-            MajorVersion = 4,
-            MinorVersion = 6,
-            RenderContinuously = true
-        };
+        var settings =
+            new GLWpfControlSettings
+            {
+                MajorVersion = 4,
+                MinorVersion = 6,
+                RenderContinuously = true
+            };
 
         Viewport.Start(settings);
+
+        Viewport.MouseLeftButtonDown +=
+            Viewport_MouseLeftButtonDown;
+
+        Viewport.MouseLeftButtonUp +=
+            Viewport_MouseLeftButtonUp;
+
+        Viewport.MouseMove +=
+            Viewport_MouseMove;
+
+        Viewport.MouseWheel +=
+            Viewport_MouseWheel;
+
+        Viewport.LostMouseCapture +=
+            Viewport_LostMouseCapture;
 
         BuildPlot();
     }
 
-    private void Viewport_Render(TimeSpan delta)
+    private void Viewport_Render(
+        TimeSpan delta)
     {
         if (Viewport.ActualWidth <= 0 ||
             Viewport.ActualHeight <= 0)
@@ -59,25 +104,28 @@ public partial class MainWindow : Window
         }
 
         DpiScale dpi =
-            VisualTreeHelper.GetDpi(Viewport);
+            VisualTreeHelper.GetDpi(
+                Viewport);
 
-        int width = Math.Max(
-            1,
-            (int)(Viewport.ActualWidth *
-                  dpi.DpiScaleX));
+        int width =
+            Math.Max(
+                1,
+                (int)(
+                    Viewport.ActualWidth *
+                    dpi.DpiScaleX));
 
-        int height = Math.Max(
-            1,
-            (int)(Viewport.ActualHeight *
-                  dpi.DpiScaleY));
+        int height =
+            Math.Max(
+                1,
+                (int)(
+                    Viewport.ActualHeight *
+                    dpi.DpiScaleY));
 
         GL.Viewport(
             0,
             0,
             width,
             height);
-
-        GL.Disable(EnableCap.DepthTest);
 
         GL.ClearColor(
             0.055f,
@@ -89,10 +137,24 @@ public partial class MainWindow : Window
             ClearBufferMask.ColorBufferBit |
             ClearBufferMask.DepthBufferBit);
 
-        /*
-         * Create the renderer only after the OpenGL context
-         * has been started.
-         */
+        if (_renderMode ==
+            GraphRenderMode.ThreeD)
+        {
+            Render3D(
+                width,
+                height);
+
+            return;
+        }
+
+        Render2D();
+    }
+
+    private void Render2D()
+    {
+        GL.Disable(
+            EnableCap.DepthTest);
+
         _curveRenderer ??=
             new CurveRenderer2D();
 
@@ -105,13 +167,11 @@ public partial class MainWindow : Window
                 -1.0f,
                 1.0f);
 
-        /*
-         * Number-line mode does not use the normal graph grid.
-         */
         if (!_isNumberLineMode &&
             ShowGridBox.IsChecked == true)
         {
-            foreach (Plot2D gridLine in _gridPlots)
+            foreach (Plot2D gridLine
+                     in _gridPlots)
             {
                 _curveRenderer.Draw(
                     gridLine,
@@ -119,14 +179,11 @@ public partial class MainWindow : Window
             }
         }
 
-        /*
-         * A number line must always draw its horizontal axis.
-         * For functions, the Show Axes checkbox controls it.
-         */
         if (_isNumberLineMode ||
             ShowAxesBox.IsChecked == true)
         {
-            foreach (Plot2D axisLine in _axisPlots)
+            foreach (Plot2D axisLine
+                     in _axisPlots)
             {
                 _curveRenderer.Draw(
                     axisLine,
@@ -134,12 +191,110 @@ public partial class MainWindow : Window
             }
         }
 
-        if (_functionPlot is not null)
+        foreach (Plot2D functionPlot
+                 in _functionPlots)
         {
             _curveRenderer.Draw(
-                _functionPlot,
+                functionPlot,
                 projection);
         }
+    }
+
+    private void Render3D(
+        int width,
+        int height)
+    {
+        GL.Enable(
+            EnableCap.DepthTest);
+
+        Ensure3DResources();
+
+        if (_surfaceMesh is null ||
+            _surfaceRenderer is null)
+        {
+            return;
+        }
+
+        if (_surfaceUploadPending)
+        {
+            _surfaceRenderer.Upload(
+                _surfaceMesh);
+
+            _surfaceUploadPending =
+                false;
+        }
+
+        float aspect =
+            width /
+            (float)Math.Max(
+                1,
+                height);
+
+        float farPlane =
+            Math.Max(
+                200.0f,
+                (float)(
+                    _orbitCamera.Distance *
+                    10.0));
+
+        Matrix4 model =
+            Matrix4.Identity;
+
+        Matrix4 view =
+            _orbitCamera.GetViewMatrix();
+
+        Matrix4 projection =
+            _orbitCamera.GetProjectionMatrix(
+                aspect,
+                50.0f,
+                0.05f,
+                farPlane);
+
+        Matrix4 mvp =
+            model *
+            view *
+            projection;
+
+        _axis3DRenderer?.Draw(
+            mvp,
+            showAxes:
+                ShowAxesBox.IsChecked == true,
+            showGrid:
+                ShowGridBox.IsChecked == true);
+
+        _surfaceRenderer.Draw(
+            mvp,
+            model,
+            wireframe:
+                WireframeBox.IsChecked == true);
+    }
+
+    private void Ensure3DResources()
+    {
+        _surfaceRenderer ??=
+            new SurfaceRenderer();
+
+        if (_axis3DRenderer is not null &&
+            _activeAxisExtent ==
+            _requestedAxisExtent)
+        {
+            return;
+        }
+
+        _axis3DRenderer?.Dispose();
+
+        float gridStep =
+            (float)CalculateNiceStep(
+                -_requestedAxisExtent,
+                _requestedAxisExtent);
+
+        _axis3DRenderer =
+            new Axis3DRenderer(
+                _requestedAxisExtent,
+                gridStep);
+
+        _activeAxisExtent =
+            _requestedAxisExtent;
     }
 
     private void Plot_Click(
@@ -153,14 +308,17 @@ public partial class MainWindow : Window
         object sender,
         RoutedEventArgs e)
     {
-        _functionPlot = null;
-
+        _functionPlots.Clear();
         _gridPlots.Clear();
         _axisPlots.Clear();
 
+        _surfaceMesh = null;
+        _surfaceUploadPending = false;
+
         _isNumberLineMode = false;
 
-        StatusText.Text = "Graph cleared";
+        StatusText.Text =
+            "Graph cleared";
 
         Viewport.InvalidateVisual();
     }
@@ -169,6 +327,20 @@ public partial class MainWindow : Window
         object sender,
         RoutedEventArgs e)
     {
+        if (_renderMode ==
+                GraphRenderMode.ThreeD &&
+            _surfaceMesh is not null)
+        {
+            FitCameraToMesh(
+                _surfaceMesh);
+
+            StatusText.Text =
+                "3D camera reset";
+
+            Viewport.InvalidateVisual();
+            return;
+        }
+
         XMinBox.Text = "-10";
         XMaxBox.Text = "10";
 
@@ -192,113 +364,13 @@ public partial class MainWindow : Window
     {
         try
         {
-            /*
-             * Index 0 is currently the supported automatic
-             * scalar-or-2D mode.
-             */
-            if (GraphTypeBox.SelectedIndex != 0)
+            if (GraphTypeBox.SelectedIndex == 1)
             {
-                throw new NotSupportedException(
-                    "3D surfaces are not connected yet. " +
-                    "Select the first graph type option.");
-            }
-
-            CompiledExpression expression =
-                ExpressionEngine.Compile(
-                    FunctionBox.Text);
-
-            /*
-             * An expression without x is a scalar calculation.
-             *
-             * Examples:
-             * 1
-             * 2 + 3 * 4
-             * pi / 2
-             * sqrt(16)
-             */
-            if (!expression.ContainsVariable)
-            {
-                double result =
-                    expression.Evaluate();
-
-                if (!double.IsFinite(result))
-                {
-                    throw new ArithmeticException(
-                        "The expression did not produce " +
-                        "a finite real number.");
-                }
-
-                BuildNumberLine(result);
-
-                StatusText.Text =
-                    $"{FunctionBox.Text.Trim()} = " +
-                    result.ToString(
-                        "G12",
-                        CultureInfo.InvariantCulture);
-
-                Viewport.InvalidateVisual();
+                Build3DSurface();
                 return;
             }
 
-            /*
-             * An expression containing x becomes a 2D function.
-             */
-            _isNumberLineMode = false;
-
-            if (!TryParseNumber(
-                    XMinBox.Text,
-                    out double xMinimum))
-            {
-                throw new FormatException(
-                    "X minimum is not a valid number.");
-            }
-
-            if (!TryParseNumber(
-                    XMaxBox.Text,
-                    out double xMaximum))
-            {
-                throw new FormatException(
-                    "X maximum is not a valid number.");
-            }
-
-            if (xMinimum >= xMaximum)
-            {
-                throw new ArgumentException(
-                    "X minimum must be smaller " +
-                    "than X maximum.");
-            }
-
-            _xMinimum = xMinimum;
-            _xMaximum = xMaximum;
-
-            int samples = Math.Max(
-                25,
-                (int)ResolutionSlider.Value);
-
-            _functionPlot =
-                Plot2DFactory.Function(
-                    expression.ToFunction(),
-                    _xMinimum,
-                    _xMaximum,
-                    samples,
-                    new PlotStyle
-                    {
-                        Lines = true,
-                        Points = false,
-                        Width = 2.5f,
-                        Rgb = new NumericsVector3(
-                            0.20f,
-                            0.80f,
-                            1.00f)
-                    });
-
-            CalculateYBounds();
-            BuildGridAndAxes();
-
-            StatusText.Text =
-                $"Plotting y = {expression.Source}";
-
-            Viewport.InvalidateVisual();
+            Build2DOrScalar();
         }
         catch (Exception exception)
         {
@@ -313,18 +385,231 @@ public partial class MainWindow : Window
         }
     }
 
-    private void BuildNumberLine(double value)
+    private void Build2DOrScalar()
     {
-        _isNumberLineMode = true;
+        CompiledExpression expression =
+            ExpressionEngine.Compile(
+                FunctionBox.Text);
+
+        if (expression.ContainsY)
+        {
+            throw new InvalidOperationException(
+                "This expression uses y. " +
+                "Select 3D Surface.");
+        }
+
+        _renderMode =
+            GraphRenderMode.TwoD;
+
+        if (!expression.ContainsVariable)
+        {
+            double result =
+                expression.Evaluate();
+
+            if (!double.IsFinite(result))
+            {
+                throw new ArithmeticException(
+                    "The expression did not produce " +
+                    "a finite real number.");
+            }
+
+            BuildNumberLine(
+                result);
+
+            StatusText.Text =
+                $"{FunctionBox.Text.Trim()} = " +
+                result.ToString(
+                    "G12",
+                    CultureInfo.InvariantCulture);
+
+            Viewport.InvalidateVisual();
+            return;
+        }
+
+        _isNumberLineMode = false;
+
+        ReadXBounds(
+            out double xMinimum,
+            out double xMaximum);
+
+        _xMinimum = xMinimum;
+        _xMaximum = xMaximum;
+
+        int samples =
+            Math.Max(
+                25,
+                (int)ResolutionSlider.Value);
+
+        FunctionSampleResult sampling =
+            FunctionSegmentSampler.Sample(
+                expression.ToFunction(),
+                _xMinimum,
+                _xMaximum,
+                samples);
+
+        if (sampling.Segments.Count == 0)
+        {
+            throw new ArithmeticException(
+                "The expression did not produce a drawable " +
+                "real-valued curve in the selected range.");
+        }
+
+        _functionPlots.Clear();
+
+        foreach (
+            IReadOnlyList<NumericsVector2> segment
+            in sampling.Segments)
+        {
+            var plot =
+                new Plot2D(
+                    CreateFunctionStyle());
+
+            foreach (
+                NumericsVector2 point
+                in segment)
+            {
+                plot.Points.Add(
+                    point);
+            }
+
+            _functionPlots.Add(
+                plot);
+        }
+
+        CalculateYBounds();
+        BuildGridAndAxes();
+
+        string segmentWord =
+            sampling.Segments.Count == 1
+                ? "segment"
+                : "segments";
+
+        string breakText =
+            sampling.BreakCount == 0
+                ? "continuous"
+                : $"{sampling.BreakCount} detected break(s)";
+
+        StatusText.Text =
+            $"Plotting y = {expression.Source} — " +
+            $"{sampling.Segments.Count} {segmentWord}, " +
+            breakText;
+
+        Viewport.InvalidateVisual();
+    }
+
+    private void Build3DSurface()
+    {
+        ReadXBounds(
+            out double minimum,
+            out double maximum);
+
+        CompiledExpression expression =
+            ExpressionEngine.Compile(
+                FunctionBox.Text);
 
         /*
-         * Keep both zero and the result visible.
+         * For the first WPF 3D version, the X minimum and maximum
+         * are used for both the mathematical x and y domains.
          */
-        double padding = Math.Max(
-            1.0,
-            Math.Abs(value) * 0.20);
+        double xMinimum = minimum;
+        double xMaximum = maximum;
+        double yMinimum = minimum;
+        double yMaximum = maximum;
 
-        if (Math.Abs(value) < 0.000001)
+        int gridResolution =
+            Math.Clamp(
+                (int)Math.Round(
+                    ResolutionSlider.Value /
+                    4.0),
+                10,
+                200);
+
+        var scalarField =
+            new DelegateScalarField(
+                expression.ToSurface());
+
+        Mesh3D mesh =
+            SurfaceFactory.BuildSurface(
+                scalarField,
+                gridResolution,
+                xMinimum,
+                xMaximum,
+                yMinimum,
+                yMaximum);
+
+        if (mesh.Indices.Length == 0)
+        {
+            throw new ArithmeticException(
+                "The expression did not produce a drawable " +
+                "3D surface in the selected range.");
+        }
+
+        _renderMode =
+            GraphRenderMode.ThreeD;
+
+        _isNumberLineMode = false;
+
+        _functionPlots.Clear();
+        _gridPlots.Clear();
+        _axisPlots.Clear();
+
+        _surfaceMesh =
+            mesh;
+
+        _surfaceUploadPending =
+            true;
+
+        _requestedAxisExtent =
+            Math.Clamp(
+                (int)Math.Ceiling(
+                    Math.Max(
+                        Math.Abs(minimum),
+                        Math.Abs(maximum))),
+                1,
+                10_000);
+
+        FitCameraToMesh(
+            mesh);
+
+        StatusText.Text =
+            $"Plotting z = {expression.Source} — " +
+            $"{gridResolution} × {gridResolution} surface. " +
+            "Drag to orbit; use the mouse wheel to zoom.";
+
+        Viewport.InvalidateVisual();
+    }
+
+    private static PlotStyle CreateFunctionStyle()
+    {
+        return new PlotStyle
+        {
+            Lines = true,
+            Points = false,
+            Width = 2.5f,
+            Rgb = new NumericsVector3(
+                0.20f,
+                0.80f,
+                1.00f)
+        };
+    }
+
+    private void BuildNumberLine(
+        double value)
+    {
+        _renderMode =
+            GraphRenderMode.TwoD;
+
+        _isNumberLineMode =
+            true;
+
+        double padding =
+            Math.Max(
+                1.0,
+                Math.Abs(value) *
+                0.20);
+
+        if (Math.Abs(value) <
+            0.000001)
         {
             _xMinimum = -5;
             _xMaximum = 5;
@@ -332,10 +617,16 @@ public partial class MainWindow : Window
         else
         {
             _xMinimum =
-                Math.Min(0.0, value) - padding;
+                Math.Min(
+                    0.0,
+                    value) -
+                padding;
 
             _xMaximum =
-                Math.Max(0.0, value) + padding;
+                Math.Max(
+                    0.0,
+                    value) +
+                padding;
         }
 
         _yMinimum = -1.0;
@@ -343,6 +634,7 @@ public partial class MainWindow : Window
 
         _gridPlots.Clear();
         _axisPlots.Clear();
+        _functionPlots.Clear();
 
         var axisColor =
             new NumericsVector3(
@@ -350,9 +642,6 @@ public partial class MainWindow : Window
                 0.85f,
                 0.85f);
 
-        /*
-         * Main horizontal number line.
-         */
         _axisPlots.Add(
             CreateLine(
                 (float)_xMinimum,
@@ -369,15 +658,16 @@ public partial class MainWindow : Window
 
         double firstTick =
             Math.Ceiling(
-                _xMinimum / tickStep) *
+                _xMinimum /
+                tickStep) *
             tickStep;
 
-        /*
-         * Tick marks along the number line.
-         */
-        for (double tick = firstTick;
-             tick <= _xMaximum + 0.000001;
-             tick += tickStep)
+        for (
+            double tick = firstTick;
+            tick <=
+                _xMaximum +
+                0.000001;
+            tick += tickStep)
         {
             _axisPlots.Add(
                 CreateLine(
@@ -389,9 +679,6 @@ public partial class MainWindow : Window
                     1.5f));
         }
 
-        /*
-         * Make zero slightly larger.
-         */
         if (_xMinimum <= 0 &&
             _xMaximum >= 0)
         {
@@ -405,44 +692,44 @@ public partial class MainWindow : Window
                     2.0f));
         }
 
-        /*
-         * Draw the evaluated result as a point.
-         */
-        _functionPlot =
+        var resultPoint =
             new Plot2D(
                 new PlotStyle
                 {
                     Lines = false,
                     Points = true,
                     Width = 12.0f,
-                    Rgb = new NumericsVector3(
-                        0.20f,
-                        0.80f,
-                        1.00f)
+                    Rgb =
+                        new NumericsVector3(
+                            0.20f,
+                            0.80f,
+                            1.00f)
                 });
 
-        _functionPlot.Points.Add(
+        resultPoint.Points.Add(
             new NumericsVector2(
                 (float)value,
                 0.0f));
+
+        _functionPlots.Add(
+            resultPoint);
     }
 
     private void CalculateYBounds()
     {
-        if (_functionPlot is null)
-        {
-            _yMinimum = -1;
-            _yMaximum = 1;
-            return;
-        }
-
         double[] finiteValues =
-            _functionPlot.Points
-                .Select(point =>
-                    (double)point.Y)
-                .Where(value =>
-                    double.IsFinite(value) &&
-                    Math.Abs(value) < 1_000_000)
+            _functionPlots
+                .SelectMany(
+                    plot =>
+                        plot.Points)
+                .Select(
+                    point =>
+                        (double)point.Y)
+                .Where(
+                    value =>
+                        double.IsFinite(value) &&
+                        Math.Abs(value) <
+                        1_000_000)
                 .ToArray();
 
         if (finiteValues.Length == 0)
@@ -459,38 +746,85 @@ public partial class MainWindow : Window
             finiteValues.Max();
 
         double range =
-            maximum - minimum;
+            maximum -
+            minimum;
 
-        if (range < 0.000001)
+        if (range <
+            0.000001)
         {
-            double center = minimum;
+            double center =
+                minimum;
 
-            _yMinimum = center - 1.0;
-            _yMaximum = center + 1.0;
+            _yMinimum =
+                center -
+                1.0;
+
+            _yMaximum =
+                center +
+                1.0;
+
             return;
         }
 
+        Array.Sort(
+            finiteValues);
+
+        int lowerIndex =
+            (int)Math.Floor(
+                (finiteValues.Length - 1) *
+                0.02);
+
+        int upperIndex =
+            (int)Math.Ceiling(
+                (finiteValues.Length - 1) *
+                0.98);
+
+        double visibleMinimum =
+            finiteValues[lowerIndex];
+
+        double visibleMaximum =
+            finiteValues[upperIndex];
+
+        double visibleRange =
+            visibleMaximum -
+            visibleMinimum;
+
+        if (visibleRange <
+            0.000001)
+        {
+            visibleMinimum =
+                minimum;
+
+            visibleMaximum =
+                maximum;
+
+            visibleRange =
+                range;
+        }
+
         double padding =
-            range * 0.15;
+            visibleRange *
+            0.15;
 
         _yMinimum =
-            minimum - padding;
+            visibleMinimum -
+            padding;
 
         _yMaximum =
-            maximum + padding;
+            visibleMaximum +
+            padding;
 
-        /*
-         * Keep zero visible when it is reasonably
-         * close to the function's range.
-         */
         if (_yMinimum > 0 &&
-            _yMinimum < range)
+            _yMinimum <
+            visibleRange)
         {
             _yMinimum = 0;
         }
 
         if (_yMaximum < 0 &&
-            Math.Abs(_yMaximum) < range)
+            Math.Abs(
+                _yMaximum) <
+            visibleRange)
         {
             _yMaximum = 0;
         }
@@ -513,12 +847,16 @@ public partial class MainWindow : Window
 
         double firstX =
             Math.Ceiling(
-                _xMinimum / xStep) *
+                _xMinimum /
+                xStep) *
             xStep;
 
-        for (double x = firstX;
-             x <= _xMaximum + 0.000001;
-             x += xStep)
+        for (
+            double x = firstX;
+            x <=
+                _xMaximum +
+                0.000001;
+            x += xStep)
         {
             _gridPlots.Add(
                 CreateLine(
@@ -535,12 +873,16 @@ public partial class MainWindow : Window
 
         double firstY =
             Math.Ceiling(
-                _yMinimum / yStep) *
+                _yMinimum /
+                yStep) *
             yStep;
 
-        for (double y = firstY;
-             y <= _yMaximum + 0.000001;
-             y += yStep)
+        for (
+            double y = firstY;
+            y <=
+                _yMaximum +
+                0.000001;
+            y += yStep)
         {
             _gridPlots.Add(
                 CreateLine(
@@ -555,9 +897,6 @@ public partial class MainWindow : Window
                     1.0f));
         }
 
-        /*
-         * Y axis.
-         */
         if (_xMinimum <= 0 &&
             _xMaximum >= 0)
         {
@@ -574,9 +913,6 @@ public partial class MainWindow : Window
                     2.0f));
         }
 
-        /*
-         * X axis.
-         */
         if (_yMinimum <= 0 &&
             _yMaximum >= 0)
         {
@@ -629,12 +965,15 @@ public partial class MainWindow : Window
         double minimum,
         double maximum)
     {
-        double span = Math.Max(
-            0.000001,
-            maximum - minimum);
+        double span =
+            Math.Max(
+                0.000001,
+                maximum -
+                minimum);
 
         double roughStep =
-            span / 10.0;
+            span /
+            10.0;
 
         double magnitude =
             Math.Pow(
@@ -644,7 +983,8 @@ public partial class MainWindow : Window
                         roughStep)));
 
         double normalized =
-            roughStep / magnitude;
+            roughStep /
+            magnitude;
 
         double niceValue =
             normalized switch
@@ -655,7 +995,37 @@ public partial class MainWindow : Window
                 _ => 10
             };
 
-        return niceValue * magnitude;
+        return
+            niceValue *
+            magnitude;
+    }
+
+    private void ReadXBounds(
+        out double minimum,
+        out double maximum)
+    {
+        if (!TryParseNumber(
+                XMinBox.Text,
+                out minimum))
+        {
+            throw new FormatException(
+                "X minimum is not a valid number.");
+        }
+
+        if (!TryParseNumber(
+                XMaxBox.Text,
+                out maximum))
+        {
+            throw new FormatException(
+                "X maximum is not a valid number.");
+        }
+
+        if (minimum >= maximum)
+        {
+            throw new ArgumentException(
+                "X minimum must be smaller " +
+                "than X maximum.");
+        }
     }
 
     private static bool TryParseNumber(
@@ -674,5 +1044,206 @@ public partial class MainWindow : Window
                 NumberStyles.Float,
                 CultureInfo.CurrentCulture,
                 out result);
+    }
+
+    private void FitCameraToMesh(
+        Mesh3D mesh)
+    {
+        if (mesh.Positions.Length == 0)
+        {
+            _orbitCamera.Target =
+                Vector3d.Zero;
+
+            _orbitCamera.Distance =
+                10.0;
+
+            return;
+        }
+
+        Vector3 minimum =
+            mesh.Positions[0];
+
+        Vector3 maximum =
+            mesh.Positions[0];
+
+        foreach (
+            Vector3 position
+            in mesh.Positions)
+        {
+            minimum =
+                Vector3.ComponentMin(
+                    minimum,
+                    position);
+
+            maximum =
+                Vector3.ComponentMax(
+                    maximum,
+                    position);
+        }
+
+        Vector3 center =
+            (minimum +
+             maximum) *
+            0.5f;
+
+        Vector3 size =
+            maximum -
+            minimum;
+
+        double radius =
+            Math.Max(
+                1.0,
+                size.Length *
+                0.5);
+
+        _orbitCamera.Target =
+            new Vector3d(
+                center.X,
+                center.Y,
+                center.Z);
+
+        _orbitCamera.Distance =
+            Math.Clamp(
+                radius *
+                2.5,
+                3.0,
+                1_000_000.0);
+
+        _orbitCamera.Yaw =
+            0.9;
+
+        _orbitCamera.Pitch =
+            0.55;
+    }
+
+    private void Viewport_MouseLeftButtonDown(
+        object sender,
+        MouseButtonEventArgs e)
+    {
+        if (_renderMode !=
+            GraphRenderMode.ThreeD)
+        {
+            return;
+        }
+
+        _isOrbiting =
+            true;
+
+        _lastMousePosition =
+            e.GetPosition(
+                Viewport);
+
+        Viewport.CaptureMouse();
+        Viewport.Focus();
+
+        e.Handled = true;
+    }
+
+    private void Viewport_MouseLeftButtonUp(
+        object sender,
+        MouseButtonEventArgs e)
+    {
+        StopOrbiting();
+        e.Handled = true;
+    }
+
+    private void Viewport_LostMouseCapture(
+        object sender,
+        MouseEventArgs e)
+    {
+        _isOrbiting = false;
+    }
+
+    private void Viewport_MouseMove(
+        object sender,
+        MouseEventArgs e)
+    {
+        if (!_isOrbiting ||
+            _renderMode !=
+            GraphRenderMode.ThreeD)
+        {
+            return;
+        }
+
+        WpfPoint currentPosition =
+            e.GetPosition(
+                Viewport);
+
+        double deltaX =
+            currentPosition.X -
+            _lastMousePosition.X;
+
+        double deltaY =
+            currentPosition.Y -
+            _lastMousePosition.Y;
+
+        _lastMousePosition =
+            currentPosition;
+
+        _orbitCamera.Yaw +=
+            deltaX *
+            0.01;
+
+        _orbitCamera.Pitch -=
+            deltaY *
+            0.01;
+
+        Viewport.InvalidateVisual();
+        e.Handled = true;
+    }
+
+    private void Viewport_MouseWheel(
+        object sender,
+        MouseWheelEventArgs e)
+    {
+        if (_renderMode !=
+            GraphRenderMode.ThreeD)
+        {
+            return;
+        }
+
+        double wheelSteps =
+            e.Delta /
+            120.0;
+
+        double zoomFactor =
+            Math.Pow(
+                0.85,
+                wheelSteps);
+
+        _orbitCamera.Distance =
+            Math.Clamp(
+                _orbitCamera.Distance *
+                zoomFactor,
+                0.25,
+                1_000_000.0);
+
+        Viewport.InvalidateVisual();
+        e.Handled = true;
+    }
+
+    private void StopOrbiting()
+    {
+        if (!_isOrbiting)
+        {
+            return;
+        }
+
+        _isOrbiting = false;
+        Viewport.ReleaseMouseCapture();
+    }
+
+    protected override void OnClosed(
+        EventArgs e)
+    {
+        try
+        {
+            _surfaceRenderer?.Dispose();
+            _axis3DRenderer?.Dispose();
+        }
+        finally
+        {
+            base.OnClosed(e);
+        }
     }
 }

--- a/Diagram2.codartis
+++ b/Diagram2.codartis
@@ -10,8 +10,8 @@
       "FullyQualifiedName": "Fluxion",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1346.5611,-3289.4199",
-      "Size": "1674.904,1377.2587",
+      "Position": "-1507.1468,-3550.4352",
+      "Size": "2002.278,1767.942",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush11",
       "Symbols": [
@@ -27,8 +27,8 @@
       "FullyQualifiedName": "Fluxion.src.Runtime",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Runtime\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-357.1621,-3089.1994",
-      "Size": "431.9099,204.0314",
+      "Position": "-283.2821,-3190.4553",
+      "Size": "446,223.8",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush4",
       "Symbols": [
@@ -44,8 +44,8 @@
       "FullyQualifiedName": "Fluxion.src",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1341.5611,-3260.6199",
-      "Size": "1664.904,1343.4587",
+      "Position": "-1502.1468,-3521.6352",
+      "Size": "1992.278,1734.142",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush3",
       "Symbols": [
@@ -61,7 +61,7 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Camera",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Camera\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-356.5272,-2481.5076",
+      "Position": "-262.2821,-2380.2553",
       "Size": "142,83.8",
       "IsPinned": true,
       "Symbols": [
@@ -77,8 +77,8 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Draw",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Draw\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-183.3089,-2613.4347",
-      "Size": "452.4514,273.6379",
+      "Position": "-60.2821,-2520.2553",
+      "Size": "452.4514,293.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Draw\",\"C\":{\"K\":\"Namespace\",\"N\":\"Rendering\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}"
@@ -93,8 +93,8 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Scene",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Scene\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-358.2768,-2740.0149",
-      "Size": "142,252.6466",
+      "Position": "-262.2821,-2734.0553",
+      "Size": "142,293.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Scene\",\"C\":{\"K\":\"Namespace\",\"N\":\"Rendering\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}"
@@ -109,8 +109,8 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Visualize2D",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Visualize2D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-193.6018,-2845.5099",
-      "Size": "294,223.8",
+      "Position": "-60.2821,-2845.6942",
+      "Size": "294,223.9843",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Visualize2D\",\"C\":{\"K\":\"Namespace\",\"N\":\"Rendering\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}"
@@ -125,7 +125,7 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Visualize3D",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Visualize3D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "129.7542,-2847.7362",
+      "Position": "293.7179,-2877.8553",
       "Size": "142,153.8",
       "IsPinned": true,
       "Symbols": [
@@ -141,7 +141,7 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Visualize4D",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Visualize4D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "116.6483,-2679.1828",
+      "Position": "293.7179,-2664.0553",
       "Size": "186.4133,83.8",
       "IsPinned": true,
       "Symbols": [
@@ -157,7 +157,7 @@
       "FullyQualifiedName": "Fluxion.src.Rendering.Windowing",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering.Windowing\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-363.1165,-2836.8818",
+      "Position": "-262.2821,-2877.8553",
       "Size": "142,83.8",
       "IsPinned": true,
       "Symbols": [
@@ -173,8 +173,8 @@
       "FullyQualifiedName": "Fluxion.src.Rendering",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Rendering\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-368.1165,-2876.5362",
-      "Size": "676.1781,541.7394",
+      "Position": "-283.2821,-2906.6553",
+      "Size": "768.4133,685.2",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush4",
       "Symbols": [
@@ -190,8 +190,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Abstractions",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Abstractions\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1323.4046,-3189.1149",
-      "Size": "142.9531,146.7158",
+      "Position": "-1391.0767,-3361.9805",
+      "Size": "142.953,153.8",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -207,8 +207,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1156.1156,-3203.0199",
-      "Size": "758.7883,612.7115",
+      "Position": "-1172.1237,-3433.8368",
+      "Size": "822.04,771.2",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -224,8 +224,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1162.0224,-2570.367",
-      "Size": "779.6531,597.3844",
+      "Position": "-1239.5937,-2602.6368",
+      "Size": "904.9019,755.2",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -241,8 +241,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Functions3D",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Functions3D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1317.5927,-2294.117",
-      "Size": "146.3547,147.4302",
+      "Position": "-1461.9483,-2173.1804",
+      "Size": "146.3547,153.8",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -258,8 +258,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Geometry4D",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Geometry4D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1318.813,-2526.3054",
-      "Size": "145.0342,244.9088",
+      "Position": "-1460.6279,-2526.9804",
+      "Size": "145.0342,293.8",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -275,8 +275,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1336.5611,-3231.8199",
-      "Size": "959.1917,1263.8373",
+      "Position": "-1466.9484,-3462.6368",
+      "Size": "1137.2566,1620.2",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush4",
       "Symbols": [
@@ -292,8 +292,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Trigonometry.Concepts",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Trigonometry.Concepts\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1325.9645,-2814.5596",
-      "Size": "146.2599,143.4893",
+      "Position": "-1415.3835,-2905.5805",
+      "Size": "146.2598,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Concepts\",\"C\":{\"K\":\"Namespace\",\"N\":\"Trigonometry\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -308,8 +308,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Trigonometry.Functions",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Trigonometry.Functions\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1326.5611,-2973.7812",
-      "Size": "143.2036,140.4747",
+      "Position": "-1412.3274,-3119.3805",
+      "Size": "143.2037,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Functions\",\"C\":{\"K\":\"Namespace\",\"N\":\"Trigonometry\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -324,7 +324,7 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Trigonometry.Sampling",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Trigonometry.Sampling\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1319.5449,-2645.262",
+      "Position": "-1413.1504,-2691.7805",
       "Size": "144.0267,83.8",
       "IsPinned": true,
       "Symbols": [
@@ -340,8 +340,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Trigonometry",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Trigonometry\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1331.5611,-3002.5812",
-      "Size": "161.0428,446.1192",
+      "Position": "-1420.3835,-3148.1805",
+      "Size": "172.2598,545.2001",
       "IsPinned": true,
       "CustomFillBrushKey": "DiagramItemCustomColorBrush10",
       "Symbols": [
@@ -357,8 +357,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Solvers",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Solvers\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1148.9563,-2301.6922",
-      "Size": "276.2545,140.8942",
+      "Position": "-1212.2195,-2290.0368",
+      "Size": "294,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Solvers\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -373,8 +373,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Concepts",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Concepts\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1157.0224,-2541.567",
-      "Size": "277.8678,212.1078",
+      "Position": "-1234.5937,-2573.8368",
+      "Size": "294,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Concepts\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -389,8 +389,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Derivatives",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Derivatives\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-857.0593,-2376.7717",
-      "Size": "284.9871,189.675",
+      "Position": "-858.2195,-2360.0368",
+      "Size": "299.3333,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Derivatives\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -405,8 +405,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.DifferentialEquations",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.DifferentialEquations\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-558.8793,-2534.3757",
-      "Size": "171.51,141.1819",
+      "Position": "-526.5937,-2573.8368",
+      "Size": "171.51,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"DifferentialEquations\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -421,8 +421,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Integrals",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Integrals\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-847.2621,-2177.9342",
-      "Size": "285.6456,199.9516",
+      "Position": "-805.6918,-2076.2368",
+      "Size": "294,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Integrals\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -437,8 +437,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Limits",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Limits\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1144.7181,-2135.0718",
-      "Size": "284.232,143.9605",
+      "Position": "-1159.6918,-2076.2368",
+      "Size": "294,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Limits\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -453,8 +453,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Operations",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Operations\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-854.3919,-2536.7274",
-      "Size": "283.1845,142.0832",
+      "Position": "-880.5937,-2573.8368",
+      "Size": "294,153.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Operations\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -469,8 +469,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Calculus.Series",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Calculus.Series\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-550.9483,-2373.4872",
-      "Size": "143.8026,194.0573",
+      "Position": "-498.8862,-2360.0368",
+      "Size": "143.8025,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Series\",\"C\":{\"K\":\"Namespace\",\"N\":\"Calculus\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -485,8 +485,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra.Concepts",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra.Concepts\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1149.9147,-2955.305",
-      "Size": "448.1217,356.5543",
+      "Position": "-1157.2054,-3047.4368",
+      "Size": "448.1217,363.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Concepts\",\"C\":{\"K\":\"Namespace\",\"N\":\"Algebra\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -501,8 +501,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra.Equations",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra.Equations\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1151.1156,-3166.5094",
-      "Size": "434.5238,200.5385",
+      "Position": "-1167.1237,-3331.2368",
+      "Size": "458.04,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Equations\",\"C\":{\"K\":\"Namespace\",\"N\":\"Algebra\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -517,8 +517,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra.Operations",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra.Operations\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-687.1628,-3174.2199",
-      "Size": "279.1124,197.8744",
+      "Position": "-649.0837,-3405.0368",
+      "Size": "294,223.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Operations\",\"C\":{\"K\":\"Namespace\",\"N\":\"Algebra\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -533,7 +533,7 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra.Sequences",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra.Sequences\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-544.3272,-2679.1085",
+      "Position": "-497.0837,-2767.4368",
       "Size": "142,83.8",
       "IsPinned": true,
       "Symbols": [
@@ -549,8 +549,8 @@
       "FullyQualifiedName": "Fluxion.src.Numerics.Algebra.Solvers",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Numerics.Algebra.Solvers\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-695.294,-2954.7346",
-      "Size": "291.7553,266.3451",
+      "Position": "-649.0837,-3121.2368",
+      "Size": "294,293.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"Solvers\",\"C\":{\"K\":\"Namespace\",\"N\":\"Algebra\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}"
@@ -564,8 +564,8 @@
       "FullyQualifiedName": "Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
       "Stereotype": "Assembly",
       "ToolTip": "assembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1351.5611,-3318.2199",
-      "Size": "1684.904,1411.0587",
+      "Position": "-1512.1468,-3579.2352",
+      "Size": "2012.278,1801.742",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}"
@@ -580,13 +580,44 @@
       "FullyQualifiedName": "Fluxion.src.Core.App",
       "Stereotype": "Namespace",
       "ToolTip": "namespace Fluxion.src.Core.App\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-354.5293,-3191.9923",
+      "Position": "-283.2821,-3334.2553",
       "Size": "173.04,83.8",
       "IsPinned": true,
       "Symbols": [
         "{\"K\":\"Namespace\",\"N\":\"App\",\"C\":{\"K\":\"Namespace\",\"N\":\"Core\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}"
       ],
       "NamespaceLevel": 4
+    },
+    {
+      "Id": 241,
+      "ZIndex": 219,
+      "Name": "Fluxion.Desktop (1.0.0.0) [Desktop]",
+      "FullyQualifiedName": "Fluxion.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "Stereotype": "Assembly",
+      "ToolTip": "assembly: Fluxion.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\r\nproject: Desktop",
+      "Position": "-745.1057,-3721.6942",
+      "Size": "357.4668,121.844",
+      "IsPinned": false,
+      "Symbols": [
+        "{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}"
+      ],
+      "NamespaceLevel": 0
+    },
+    {
+      "Id": 244,
+      "ParentId": 241,
+      "ZIndex": 222,
+      "Name": "Desktop",
+      "FullyQualifiedName": "Fluxion.Desktop",
+      "Stereotype": "Namespace",
+      "ToolTip": "namespace Fluxion.Desktop\r\nassembly: Fluxion.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "Position": "-740.1057,-3692.8942",
+      "Size": "347.4668,88.044",
+      "IsPinned": true,
+      "Symbols": [
+        "{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}"
+      ],
+      "NamespaceLevel": 2
     }
   ],
   "LeafNodes": [
@@ -597,7 +628,7 @@
       "Name": "Lift",
       "Stereotype": "Enum",
       "ToolTip": "enum Fluxion.src.Runtime.Lift\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-214.6812,-2940.1681",
+      "Position": "-126.2821,-3021.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -619,7 +650,7 @@
       "Name": "EmbedPlane",
       "Stereotype": "Enum",
       "ToolTip": "enum Fluxion.src.Runtime.EmbedPlane\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-352.1621,-2945.0077",
+      "Position": "-278.2821,-3021.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -641,7 +672,7 @@
       "Name": "Graph",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Runtime.Graph\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-213.0679,-3003.6139",
+      "Position": "-126.2821,-3091.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -663,7 +694,7 @@
       "Name": "Graph1D",
       "Stereotype": "Struct",
       "ToolTip": "readonly struct Fluxion.src.Runtime.Graph1D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-68.7051,-3052.5358",
+      "Position": "25.7179,-3161.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -685,7 +716,7 @@
       "Name": "Graph2D",
       "Stereotype": "Struct",
       "ToolTip": "readonly struct Fluxion.src.Runtime.Graph2D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-209.8415,-3060.3994",
+      "Position": "-126.2821,-3161.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -707,7 +738,7 @@
       "Name": "GraphLine",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Runtime.GraphLine\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-347.3225,-3060.1114",
+      "Position": "-278.2821,-3161.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -729,7 +760,7 @@
       "Name": "GraphPoints",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Runtime.GraphPoints\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-348.9357,-3005.4346",
+      "Position": "-278.2821,-3091.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -751,7 +782,7 @@
       "Name": "Graph2DFeature",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Runtime.Graph2DFeature\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-62.2522,-2941.3768",
+      "Position": "25.7179,-3021.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -773,7 +804,7 @@
       "Name": "Graph3DFeature",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Runtime.Graph3DFeature\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-67.0919,-2993.6313",
+      "Position": "25.7179,-3091.6553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -795,7 +826,7 @@
       "Name": "OrbitCamera",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Camera.OrbitCamera\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-351.5272,-2452.7076",
+      "Position": "-257.2821,-2351.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -817,7 +848,7 @@
       "Name": "Axes2DOptions",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.Axes2DOptions\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-173.8024,-2457.6563",
+      "Position": "-55.2821,-2351.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -839,7 +870,7 @@
       "Name": "Axes2DRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.Axes2DRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-25.4076,-2460.577",
+      "Position": "96.7179,-2351.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -861,7 +892,7 @@
       "Name": "Axis3DRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.Axis3DRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-19.0414,-2581.5886",
+      "Position": "96.7179,-2491.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -883,7 +914,7 @@
       "Name": "AxesRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.AxesRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-178.3089,-2584.6347",
+      "Position": "-55.2821,-2491.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -905,7 +936,7 @@
       "Name": "ConsoleRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.ConsoleRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-18.6485,-2399.4855",
+      "Position": "96.7179,-2281.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -927,7 +958,7 @@
       "Name": "CurveRenderer2D",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.CurveRenderer2D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-177.5624,-2520.5701",
+      "Position": "-55.2821,-2421.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -949,7 +980,7 @@
       "Name": "IRenderer",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Rendering.Draw.IRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-18.707,-2520.2278",
+      "Position": "96.7179,-2421.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -971,7 +1002,7 @@
       "Name": "OpenGLRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.OpenGLRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-175.6046,-2394.7968",
+      "Position": "-55.2821,-2281.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -993,7 +1024,7 @@
       "Name": "SurfaceRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Draw.SurfaceRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "132.1425,-2576.0611",
+      "Position": "248.7179,-2491.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1015,7 +1046,7 @@
       "Name": "IScene",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Rendering.Scene.IScene\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-353.2768,-2711.2149",
+      "Position": "-257.2821,-2705.2553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1037,7 +1068,7 @@
       "Name": "Plot2DScene",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Scene.Plot2DScene\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-353.2768,-2656.5004",
+      "Position": "-257.2821,-2635.2553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1059,7 +1090,7 @@
       "Name": "PlotRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Scene.PlotRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-353.2768,-2595.9069",
+      "Position": "-257.2821,-2565.2553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1081,7 +1112,7 @@
       "Name": "Surface3DScene",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Scene.Surface3DScene\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-353.2768,-2542.3683",
+      "Position": "-257.2821,-2495.2553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1103,7 +1134,7 @@
       "Name": "GraphLinear",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize2D.GraphLinear\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-36.6018,-2814.3746",
+      "Position": "96.7179,-2816.8942",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1125,7 +1156,7 @@
       "Name": "Plot2D",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize2D.Plot2D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-188.6018,-2746.7099",
+      "Position": "-55.2821,-2746.7099",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1147,7 +1178,7 @@
       "Name": "Plot2DFactory",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize2D.Plot2DFactory\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-39.3057,-2749.7824",
+      "Position": "96.7179,-2746.8942",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1169,7 +1200,7 @@
       "Name": "PlotRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize2D.PlotRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-188.6018,-2676.7099",
+      "Position": "-55.2821,-2676.7099",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1191,7 +1222,7 @@
       "Name": "PlotStyle",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize2D.PlotStyle\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-188.6018,-2816.7099",
+      "Position": "-55.2821,-2816.7099",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1213,7 +1244,7 @@
       "Name": "Mesh3D",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize3D.Mesh3D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "134.7542,-2748.9362",
+      "Position": "298.7179,-2779.0553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1235,7 +1266,7 @@
       "Name": "SurfaceFactory",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize3D.SurfaceFactory\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "134.7542,-2818.9362",
+      "Position": "298.7179,-2849.0553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1257,7 +1288,7 @@
       "Name": "TesseractWireframeRenderer",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Visualize4D.TesseractWireframeRenderer\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "121.6483,-2650.3828",
+      "Position": "298.7179,-2635.2553",
       "MemberAreaSize": "176.4133,0",
       "IsPinned": true,
       "Symbols": [
@@ -1279,7 +1310,7 @@
       "Name": "FluxWindow",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Rendering.Windowing.FluxWindow\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-358.1165,-2808.0818",
+      "Position": "-257.2821,-2849.0553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1301,7 +1332,7 @@
       "Name": "IEquation",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Numerics.Abstractions.IEquation\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1317.4516,-3097.3991",
+      "Position": "-1385.1237,-3263.1805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1323,7 +1354,7 @@
       "Name": "IDisplay",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Numerics.Abstractions.IDisplay\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1318.4046,-3160.3149",
+      "Position": "-1385.1237,-3333.1805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1345,7 +1376,7 @@
       "Name": "AlgebraUtils",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.AlgebraUtils\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-693.7499,-2670.5104",
+      "Position": "-669.0837,-2720.4539",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1367,7 +1398,7 @@
       "Name": "CalculusUtils",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.CalculusUtils\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-548.015,-2103.6611",
+      "Position": "-471.6918,-2096.2367",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1389,7 +1420,7 @@
       "Name": "IScalarField",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Numerics.Functions3D.IScalarField\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1308.238,-2201.6868",
+      "Position": "-1452.5937,-2074.3804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1411,7 +1442,7 @@
       "Name": "DelegateScalarField",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Functions3D.DelegateScalarField\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1312.5927,-2265.317",
+      "Position": "-1452.5937,-2144.3804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1433,7 +1464,7 @@
       "Name": "Projection4DMode",
       "Stereotype": "Enum",
       "ToolTip": "enum Fluxion.src.Numerics.Geometry4D.Projection4DMode\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1313.813,-2497.5054",
+      "Position": "-1452.5937,-2498.1804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1455,7 +1486,7 @@
       "Name": "Projector4Dto3D",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Geometry4D.Projector4Dto3D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1311.6593,-2391.4297",
+      "Position": "-1452.5937,-2358.1804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1477,7 +1508,7 @@
       "Name": "Rotation4D",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Geometry4D.Rotation4D\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1310.7788,-2336.3966",
+      "Position": "-1452.5937,-2288.1804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1499,7 +1530,7 @@
       "Name": "TesseractModel",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Geometry4D.TesseractModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1313.1356,-2441.4743",
+      "Position": "-1452.5937,-2428.1804",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1521,7 +1552,7 @@
       "Name": "SineModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Trigonometry.Concepts.SineModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1320.9645,-2726.0703",
+      "Position": "-1406.1237,-2806.7805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1543,7 +1574,7 @@
       "Name": "CosineModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Trigonometry.Concepts.CosineModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1316.7047,-2785.7596",
+      "Position": "-1406.1237,-2876.7805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1565,7 +1596,7 @@
       "Name": "CosineEquation",
       "Stereotype": "Struct",
       "ToolTip": "readonly struct Fluxion.src.Numerics.Trigonometry.Functions.CosineEquation\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1320.3574,-2944.9812",
+      "Position": "-1406.1237,-3090.5805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1587,7 +1618,7 @@
       "Name": "SineEquation",
       "Stereotype": "Struct",
       "ToolTip": "readonly struct Fluxion.src.Numerics.Trigonometry.Functions.SineEquation\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1321.5611,-2888.3065",
+      "Position": "-1406.1237,-3020.5805",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1609,7 +1640,7 @@
       "Name": "TrigonometrySampler",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Trigonometry.Sampling.TrigonometrySampler\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1314.5449,-2616.462",
+      "Position": "-1408.1504,-2662.9805",
       "MemberAreaSize": "134.0267,0",
       "IsPinned": true,
       "Symbols": [
@@ -1631,7 +1662,7 @@
       "Name": "NumericalIntegration",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Solvers.NumericalIntegration\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1068.5495,-2215.798",
+      "Position": "-1055.2195,-2191.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1653,7 +1684,7 @@
       "Name": "ODESolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Solvers.ODESolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1009.7018,-2271.279",
+      "Position": "-1055.2195,-2261.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1675,7 +1706,7 @@
       "Name": "RootFinding",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Solvers.RootFinding\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1143.9563,-2272.8922",
+      "Position": "-1207.2195,-2261.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1697,7 +1728,7 @@
       "Name": "IFunction",
       "Stereotype": "Interface",
       "ToolTip": "interface Fluxion.src.Numerics.Calculus.Concepts.IFunction\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1148.796,-2507.5228",
+      "Position": "-1229.5937,-2545.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1719,7 +1750,7 @@
       "Name": "LambdaFunction",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Concepts.LambdaFunction\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1152.0224,-2446.7977",
+      "Position": "-1229.5937,-2475.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1741,7 +1772,7 @@
       "Name": "LimitModel",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Concepts.LimitModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1016.1547,-2448.8154",
+      "Position": "-1077.5937,-2475.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1763,7 +1794,7 @@
       "Name": "ApproachDirection",
       "Stereotype": "Enum",
       "ToolTip": "enum Fluxion.src.Numerics.Calculus.Concepts.ApproachDirection\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1019.3811,-2512.767",
+      "Position": "-1077.5937,-2545.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1785,7 +1816,7 @@
       "Name": "SeriesModel",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Concepts.SeriesModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1088.4729,-2384.4592",
+      "Position": "-1077.5937,-2405.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1807,7 +1838,7 @@
       "Name": "ChainRule",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.ChainRule\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-709.0722,-2242.2209",
+      "Position": "-695.8862,-2191.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1829,7 +1860,7 @@
       "Name": "HigherOrder",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.HigherOrder\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-717.1839,-2347.9717",
+      "Position": "-695.8862,-2331.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1851,7 +1882,7 @@
       "Name": "ImplicitRelatedRates",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.ImplicitRelatedRates\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-711.8505,-2295.9976",
+      "Position": "-695.8862,-2261.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1873,7 +1904,7 @@
       "Name": "LinearizationTangent",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.LinearizationTangent\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-852.0593,-2347.9717",
+      "Position": "-847.8862,-2331.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1895,7 +1926,7 @@
       "Name": "ProductQuotientRules",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.ProductQuotientRules\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-852.0593,-2297.8002",
+      "Position": "-853.2195,-2261.2368",
       "MemberAreaSize": "137.3333,0",
       "IsPinned": true,
       "Symbols": [
@@ -1917,7 +1948,7 @@
       "Name": "RulesBasics",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Derivatives.RulesBasics\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-848.4541,-2242.0968",
+      "Position": "-847.8862,-2191.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1939,7 +1970,7 @@
       "Name": "FirstOrderLinear",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.DifferentialEquations.FirstOrderLinear\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-552.978,-2505.5757",
+      "Position": "-521.5937,-2545.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1961,7 +1992,7 @@
       "Name": "Separable",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.DifferentialEquations.Separable\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-553.8793,-2448.1939",
+      "Position": "-521.5937,-2475.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -1983,7 +2014,7 @@
       "Name": "AntiderivativesBasics",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Integrals.AntiderivativesBasics\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-763.5291,-2032.9826",
+      "Position": "-733.3307,-1907.4368",
       "MemberAreaSize": "134.7233,0",
       "IsPinned": true,
       "Symbols": [
@@ -2005,7 +2036,7 @@
       "Name": "ImproperIntegrals",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Integrals.ImproperIntegrals\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-842.2621,-2144.8937",
+      "Position": "-800.6918,-2047.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2027,7 +2058,7 @@
       "Name": "IntegrationByParts",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Integrals.IntegrationByParts\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-840.6822,-2092.9932",
+      "Position": "-800.6918,-1977.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2049,7 +2080,7 @@
       "Name": "PartialFractions",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Integrals.PartialFractions\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-698.6165,-2093.8657",
+      "Position": "-648.6918,-1977.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2071,7 +2102,7 @@
       "Name": "USubstitution",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Integrals.USubstitution\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-701.4907,-2149.1342",
+      "Position": "-648.6918,-2047.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2093,7 +2124,7 @@
       "Name": "AlgebraicLimits",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Limits.AlgebraicLimits\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-997.4861,-2106.2372",
+      "Position": "-1002.6918,-2047.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2115,7 +2146,7 @@
       "Name": "LHospitalsRule",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Limits.LHospitalsRule\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1059.0569,-2046.1113",
+      "Position": "-1028.8585,-1977.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2137,7 +2168,7 @@
       "Name": "LimitsBasics",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Limits.LimitsBasics\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1139.7181,-2106.2718",
+      "Position": "-1154.6918,-2047.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2159,7 +2190,7 @@
       "Name": "Differentiate",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Operations.Differentiate\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-849.3919,-2507.9274",
+      "Position": "-875.5937,-2545.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2181,7 +2212,7 @@
       "Name": "Integrate",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Operations.Integrate\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-848.4906,-2454.1507",
+      "Position": "-875.5937,-2475.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2203,7 +2234,7 @@
       "Name": "Limit",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Operations.Limit\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-712.7139,-2504.3222",
+      "Position": "-723.5937,-2545.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2225,7 +2256,7 @@
       "Name": "SeriesOps",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Operations.SeriesOps\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-708.2074,-2449.6442",
+      "Position": "-723.5937,-2475.0368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2247,7 +2278,7 @@
       "Name": "PowerSeries",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Series.PowerSeries\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-544.1458,-2290.0092",
+      "Position": "-493.8862,-2261.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2269,7 +2300,7 @@
       "Name": "ConvergenceTests",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Series.ConvergenceTests\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-545.9483,-2234.4299",
+      "Position": "-493.8862,-2191.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2291,7 +2322,7 @@
       "Name": "TaylorMaclaurin",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Calculus.Series.TaylorMaclaurin\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-544.1458,-2344.6872",
+      "Position": "-493.8862,-2331.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2313,7 +2344,7 @@
       "Name": "LinearEquation",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Concepts.LinearEquation\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1144.9147,-2725.4545",
+      "Position": "-1150.0837,-2808.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2335,7 +2366,7 @@
       "Name": "LinearModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.LinearModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1134.1348,-2860.8746",
+      "Position": "-1150.0837,-2948.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2357,7 +2388,7 @@
       "Name": "QuadraticModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.QuadraticModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-990.3834,-2856.268",
+      "Position": "-998.0837,-2948.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2379,7 +2410,7 @@
       "Name": "PolynomialModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.PolynomialModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-986.1581,-2782.9686",
+      "Position": "-998.0837,-2878.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2401,7 +2432,7 @@
       "Name": "RationalModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.RationalModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-846.3127,-2858.6196",
+      "Position": "-846.0837,-2910.9946",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2423,7 +2454,7 @@
       "Name": "ExponentialModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.ExponentialModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1137.6622,-2926.376",
+      "Position": "-1150.0837,-3018.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2445,7 +2476,7 @@
       "Name": "LogarithmicModel",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.LogarithmicModel\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-994.6846,-2926.505",
+      "Position": "-998.0837,-3018.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2467,7 +2498,7 @@
       "Name": "System2x2Model",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.System2x2Model\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-848.4895,-2925.3292",
+      "Position": "-846.0837,-2980.9946",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2489,7 +2520,7 @@
       "Name": "RealSolutions",
       "Stereotype": "Struct",
       "ToolTip": "readonly record struct Fluxion.src.Numerics.Algebra.Concepts.RealSolutions\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1136.4864,-2792.9182",
+      "Position": "-1150.0837,-2878.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2511,7 +2542,7 @@
       "Name": "FormulaItem",
       "Stereotype": "Class",
       "ToolTip": "record Fluxion.src.Numerics.Algebra.Concepts.FormulaItem\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-838.793,-2794.3907",
+      "Position": "-846.0837,-2840.9946",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2533,7 +2564,7 @@
       "Name": "AlgebraTopic",
       "Stereotype": "Class",
       "ToolTip": "record Fluxion.src.Numerics.Algebra.Concepts.AlgebraTopic\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-999.2315,-2720.3497",
+      "Position": "-998.0837,-2808.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2555,7 +2586,7 @@
       "Name": "Linear",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Concepts.Linear\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-843.966,-2725.8649",
+      "Position": "-846.0837,-2770.9946",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2577,7 +2608,7 @@
       "Name": "AlgebraSeeds",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Concepts.AlgebraSeeds\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1141.5046,-2653.7507",
+      "Position": "-1111.3062,-2738.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2599,7 +2630,7 @@
       "Name": "Exponential",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Exponential\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1005.8737,-3134.182",
+      "Position": "-975.6753,-3302.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2621,7 +2652,7 @@
       "Name": "Linear",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Linear\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1146.1156,-3136.5336",
+      "Position": "-1162.1237,-3232.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2643,7 +2674,7 @@
       "Name": "Logarithmic",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Logarithmic\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1143.482,-3082.995",
+      "Position": "-1150.0837,-3162.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2665,7 +2696,7 @@
       "Name": "Polynomial",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Polynomial\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1011.0577,-3020.9709",
+      "Position": "-998.0837,-3162.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2687,7 +2718,7 @@
       "Name": "Quadratic",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Quadratic\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-1007.9434,-3081.8192",
+      "Position": "-1010.1237,-3232.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2709,7 +2740,7 @@
       "Name": "Rational",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.Rational\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-866.5257,-3081.8192",
+      "Position": "-846.0837,-3162.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2731,7 +2762,7 @@
       "Name": "SystemOfEquations2x2",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Equations.SystemOfEquations2x2\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-865.6318,-3137.7094",
+      "Position": "-858.1237,-3232.4368",
       "MemberAreaSize": "144.04,0",
       "IsPinned": true,
       "Symbols": [
@@ -2753,7 +2784,7 @@
       "Name": "Factorization",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Operations.Factorization\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-545.0504,-3031.3455",
+      "Position": "-492.0837,-3236.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2775,7 +2806,7 @@
       "Name": "PrimeFinder",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Operations.PrimeFinder\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-546.6601,-3089.4615",
+      "Position": "-492.0837,-3306.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2797,7 +2828,7 @@
       "Name": "Simplify",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Operations.Simplify\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-609.2626,-3145.4199",
+      "Position": "-579.0642,-3376.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2819,7 +2850,7 @@
       "Name": "Solve",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Operations.Solve\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-682.1628,-3088.0458",
+      "Position": "-644.0837,-3306.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2841,7 +2872,7 @@
       "Name": "Substitution",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Operations.Substitution\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-680.987,-3033.0234",
+      "Position": "-644.0837,-3236.2368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2863,7 +2894,7 @@
       "Name": "FibonacciSequence",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Sequences.FibonacciSequence\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-539.3272,-2650.3085",
+      "Position": "-492.0837,-2738.6368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2885,7 +2916,7 @@
       "Name": "ExponentialSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.ExponentialSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-690.294,-2925.9346",
+      "Position": "-644.0837,-3092.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2907,7 +2938,7 @@
       "Name": "LogarithmicSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.LogarithmicSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-681.38,-2743.3895",
+      "Position": "-644.0837,-2882.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2929,7 +2960,7 @@
       "Name": "PolynomialSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.PolynomialSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-540.5386,-2745.135",
+      "Position": "-492.0837,-2882.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2951,7 +2982,7 @@
       "Name": "QuadraticSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.QuadraticSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-543.068,-2811.9372",
+      "Position": "-492.0837,-2952.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2973,7 +3004,7 @@
       "Name": "RationalSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.RationalSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-688.7654,-2871.2201",
+      "Position": "-644.0837,-3022.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -2995,7 +3026,7 @@
       "Name": "SystemSolver2x2",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.SystemSolver2x2\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-549.8641,-2866.9428",
+      "Position": "-492.0837,-3022.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -3017,7 +3048,7 @@
       "Name": "SystemSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.SystemSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-683.7893,-2813.7703",
+      "Position": "-644.0837,-2952.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -3039,7 +3070,7 @@
       "Name": "LinearSolver",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Numerics.Algebra.Solvers.LinearSolver\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-552.5198,-2922.9411",
+      "Position": "-492.0837,-3092.4368",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -3061,7 +3092,7 @@
       "Name": "Program",
       "Stereotype": "Class",
       "ToolTip": "class Fluxion.src.Core.App.Program\r\nassembly: Fluxion, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-      "Position": "-343.5555,-3163.1923",
+      "Position": "-278.2821,-3305.4553",
       "MemberAreaSize": "132,0",
       "IsPinned": true,
       "Symbols": [
@@ -3072,6 +3103,50 @@
       "IsDescriptionVisible": false,
       "IsAbstract": false,
       "IsStatic": true,
+      "Accessibility": "Public",
+      "Origin": "SourceCode",
+      "IsDisposable": false
+    },
+    {
+      "Id": 245,
+      "ParentId": 244,
+      "ZIndex": 223,
+      "Name": "GraphRequest",
+      "Stereotype": "Class",
+      "ToolTip": "record Fluxion.Desktop.GraphRequest\r\nassembly: Fluxion.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "Position": "-735.1057,-3659.8502",
+      "MemberAreaSize": "132,0",
+      "IsPinned": true,
+      "Symbols": [
+        "{\"K\":\"NamedType\",\"N\":\"GraphRequest\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}"
+      ],
+      "FullName": "record Fluxion.Desktop.GraphRequest",
+      "Description": "",
+      "IsDescriptionVisible": false,
+      "IsAbstract": false,
+      "IsStatic": false,
+      "Accessibility": "Public",
+      "Origin": "SourceCode",
+      "IsDisposable": false
+    },
+    {
+      "Id": 246,
+      "ParentId": 244,
+      "ZIndex": 224,
+      "Name": "MainWindow",
+      "Stereotype": "Class",
+      "ToolTip": "class Fluxion.Desktop.MainWindow\r\nassembly: Fluxion.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+      "Position": "-596.129,-3663.3869",
+      "MemberAreaSize": "132,0",
+      "IsPinned": true,
+      "Symbols": [
+        "{\"K\":\"NamedType\",\"N\":\"MainWindow\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}"
+      ],
+      "FullName": "class Fluxion.Desktop.MainWindow",
+      "Description": "MainWindow",
+      "IsDescriptionVisible": false,
+      "IsAbstract": false,
+      "IsStatic": false,
       "Accessibility": "Public",
       "Origin": "SourceCode",
       "IsDisposable": false
@@ -3086,13 +3161,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          47.33941332177978,
-          -2399.4855442199146,
+          162.71790701001757,
+          -2281.4552703125005,
           true
         ],
         [
-          47.305145908821082,
-          -2470.2278155258246,
+          162.71790701001757,
+          -2371.4552703125005,
           true
         ]
       ],
@@ -3106,13 +3181,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -78.3328940958224,
-          -2394.7967822284318,
+          37.860764152874694,
+          -2281.4552703125005,
           true
         ],
         [
-          16.021344846983833,
-          -2470.2278155258246,
+          135.57504986716043,
+          -2371.4552703125005,
           true
         ]
       ],
@@ -3126,13 +3201,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -226.41057463256129,
-          -2606.5004292338963,
+          -156.16387324033005,
+          -2585.2552703125,
           true
         ],
         [
-          -173.17515035725762,
-          -2584.6346912215959,
+          -24.4003127396348,
+          -2491.4552703125005,
           true
         ]
       ],
@@ -3146,13 +3221,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -254.95983131103463,
-          -2606.5004292338963,
+          -167.66188719016947,
+          -2585.2552703125,
           true
         ],
         [
-          -143.87935778927022,
-          -2520.5700551671393,
+          -12.902298789795378,
+          -2421.4552703125005,
           true
         ]
       ],
@@ -3166,13 +3241,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -287.2768306049831,
-          -2656.5004292338963,
+          -191.2820929899824,
+          -2635.2552703125,
           true
         ],
         [
-          -287.2768306049831,
-          -2661.2148946899006,
+          -191.2820929899824,
+          -2655.2552703125,
           true
         ]
       ],
@@ -3186,13 +3261,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -286.78897551528695,
-          -2492.3682569237353,
+          -191.2820929899824,
+          -2445.2552703125,
           true
         ],
         [
-          -286.0150295475276,
-          -2452.7076085003819,
+          -191.2820929899824,
+          -2351.4552703125005,
           true
         ]
       ],
@@ -3206,13 +3281,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -314.10584810060953,
-          -2531.075686219453,
+          -218.11114109059196,
+          -2483.9626565319531,
           false
         ],
         [
-          132.14252026848351,
-          -2534.5748991749319,
+          248.71792727850104,
+          -2449.9690694874325,
           false
         ]
       ],
@@ -3226,13 +3301,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -221.27683060498308,
-          -2525.1129201560561,
+          -125.28209298998243,
+          -2469.5467957362289,
           true
         ],
         [
-          -19.041412247121798,
-          -2548.8439081686179,
+          96.717907010017569,
+          -2467.1637448887718,
           true
         ]
       ],
@@ -3246,13 +3321,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -287.2768306049831,
-          -2542.3682569237353,
+          -191.2820929899824,
+          -2495.2552703125,
           true
         ],
         [
-          -287.2768306049831,
-          -2661.2148946899006,
+          -191.2820929899824,
+          -2655.2552703125,
           true
         ]
       ],
@@ -3266,13 +3341,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -241.64002199922692,
-          -2656.5004292338963,
+          -145.97217617321746,
+          -2635.2552703125,
           true
         ],
         [
-          -168.23865511465411,
-          -2696.7099493159571,
+          -34.592009806747384,
+          -2696.7099000003541,
           true
         ]
       ],
@@ -3286,13 +3361,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -122.60184650889795,
-          -2746.7099493159571,
+          10.717907010017562,
+          -2746.7099000003541,
           true
         ],
         [
-          -122.60184650889795,
-          -2766.7099493159571,
+          10.717907010017562,
+          -2766.7099000003532,
           true
         ]
       ],
@@ -3306,13 +3381,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -221.27683060498308,
-          -2541.0073137436675,
+          -125.2821235949655,
+          -2493.8942840561676,
           false
         ],
         [
-          192.53549984679728,
-          -2737.6436098526742,
+          356.49920685681485,
+          -2767.762680165175,
           false
         ]
       ],
@@ -3326,13 +3401,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -290.86745107104269,
-          -2758.0817680095111,
+          -191.2820929899824,
+          -2799.0552703125009,
           true
         ],
         [
-          -288.52588329790154,
-          -2711.2148946899006,
+          -191.2820929899824,
+          -2705.2552703125,
           true
         ]
       ],
@@ -3346,13 +3421,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1244.8817691837776,
-          -2215.3170347746186,
+          -1386.5936749242098,
+          -2094.3804302532421,
           true
         ],
         [
-          -1243.9489601747391,
-          -2201.6868441387346,
+          -1386.5936749242098,
+          -2074.3804302532421,
           true
         ]
       ],
@@ -3366,13 +3441,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1280.3017617140761,
-          -2933.6886188593107,
+          -1366.0680366383572,
+          -3079.2879200197422,
           false
         ],
         [
-          -1245.3451014289731,
-          -3047.3991305663981,
+          -1313.017176353183,
+          -3213.1805678892688,
           false
         ]
       ],
@@ -3386,13 +3461,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1254.1307156872533,
-          -2944.981189563593,
+          -1337.9596191874953,
+          -3090.5805011604316,
           true
         ],
         [
-          -1252.6313507873363,
-          -3110.3148816331136,
+          -1321.287730660996,
+          -3283.1805373228708,
           true
         ]
       ],
@@ -3406,13 +3481,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1253.7838972664069,
-          -2894.981189563593,
+          -1340.1236749242728,
+          -3040.5805011604316,
           true
         ],
         [
-          -1251.2781960581744,
-          -2785.7596494481008,
+          -1340.1236749242184,
+          -2876.7805011604319,
           true
         ]
       ],
@@ -3426,13 +3501,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1255.0697043994303,
-          -2888.3064735612156,
+          -1337.9596191874441,
+          -3020.5805011604316,
           true
         ],
         [
-          -1251.9429209702369,
-          -3047.3991305663981,
+          -1321.28773066099,
+          -3213.1805373228708,
           true
         ]
       ],
@@ -3446,13 +3521,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1255.2709477123783,
-          -2888.3064735612156,
+          -1338.4442125465309,
+          -3020.5805011604316,
           true
         ],
         [
-          -1252.6947357668278,
-          -3110.3148816331136,
+          -1320.8031373019032,
+          -3283.1805373228708,
           true
         ]
       ],
@@ -3466,13 +3541,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1255.4691294353759,
-          -2838.3064735612156,
+          -1340.1236749242225,
+          -2970.5805011604316,
           true
         ],
         [
-          -1255.0564540455903,
-          -2726.0703471540369,
+          -1340.1236749242116,
+          -2806.7805011604319,
           true
         ]
       ],
@@ -3486,13 +3561,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1084.6941098460813,
-          -2446.7976525669596,
+          -1163.5936748328825,
+          -2475.0367826903625,
           true
         ],
         [
-          -1084.1242596080199,
-          -2457.522837999416,
+          -1163.5936748328825,
+          -2495.0367826903625,
           true
         ]
       ],
@@ -3506,13 +3581,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1006.6386912641744,
-          -2448.8154087036987,
+          -1065.8793891185967,
+          -2475.0367826903625,
           true
         ],
         [
-          -1026.3119220531871,
-          -2457.522837999416,
+          -1109.3079605471682,
+          -2495.0367826903625,
           true
         ]
       ],
@@ -3526,13 +3601,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -951.4159377009272,
-          -2448.8154087036987,
+          -1011.5936748328825,
+          -2475.0367826903625,
           true
         ],
         [
-          -952.119817024999,
-          -2462.7670429088084,
+          -1011.5936748328825,
+          -2495.0367826903625,
           true
         ]
       ],
@@ -3546,13 +3621,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -826.52673193915871,
-          -2808.6195967401618,
+          -846.08367492421,
+          -2871.9445213218473,
           true
         ],
         [
-          -873.94413029726877,
-          -2782.9686105850815,
+          -866.08367492421,
+          -2867.6869103374625,
           true
         ]
       ],
@@ -3566,13 +3641,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -879.0592911508802,
-          -2720.3497310109465,
+          -866.08367492421,
+          -2797.6869103374625,
           true
         ],
         [
-          -826.96524825714584,
-          -2744.390665828153,
+          -846.08367492421,
+          -2801.9445213218473,
           true
         ]
       ],
@@ -3586,13 +3661,13 @@
       "Stereotype": "Inheritance",
       "RoutePoints": [
         [
-          -843.96599975626714,
-          -2700.7748874543395,
+          -846.08367492421,
+          -2754.1669478671342,
           true
         ],
         [
-          -1012.9147192540752,
-          -2700.5444804654717,
+          -1018.0836749242101,
+          -2775.4644837921755,
           true
         ]
       ],
@@ -3606,13 +3681,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1022.0980167871852,
-          -2653.7506752214522,
+          -1004.8695722877933,
+          -2738.6367940889927,
           true
         ],
         [
-          -986.63807963978559,
-          -2670.3497310109465,
+          -972.52028457064421,
+          -2758.6367940889936,
           true
         ]
       ],
@@ -3626,13 +3701,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1005.8736661799242,
-          -3101.3904734187308,
+          -975.67528193422766,
+          -3271.1089808873244,
           true
         ],
         [
-          -1185.451574686874,
-          -3080.1906645846129,
+          -1253.12367492421,
+          -3244.5083505245398,
           true
         ]
       ],
@@ -3646,13 +3721,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1005.8736661799242,
-          -3114.7007236000823,
+          -975.67528193422766,
+          -3282.3924541628271,
           true
         ],
         [
-          -1186.4046327964129,
-          -3129.796165469977,
+          -1253.12367492421,
+          -3303.224877249037,
           true
         ]
       ],
@@ -3666,13 +3741,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -955.72841890211919,
-          -3084.1820074369457,
+          -925.03895291643187,
+          -3252.4367940889933,
           true
         ],
         [
-          -1055.8074541332585,
-          -2926.3759587007853,
+          -1068.7200039420059,
+          -3018.6367940889936,
           true
         ]
       ],
@@ -3686,13 +3761,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1088.3342009412256,
-          -3125.2410574317396,
+          -1104.3422758654356,
+          -3221.1442515207327,
           false
         ],
         [
-          -1185.451574686874,
-          -3047.3991305663981,
+          -1253.12367492421,
+          -3213.1805678892688,
           false
         ]
       ],
@@ -3706,13 +3781,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1146.1155626845427,
-          -3120.6436821271946,
+          -1151.4620991383827,
+          -3232.4367940889933,
           true
         ],
         [
-          -1186.4046327964129,
-          -3126.2048276419409,
+          -1263.7852507100374,
+          -3283.1805373228708,
           true
         ]
       ],
@@ -3726,13 +3801,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1079.0290042768977,
-          -3086.5336281360219,
+          -1095.063068863604,
+          -3182.4367940889933,
           true
         ],
         [
-          -1069.2213342144844,
-          -2860.8745656915476,
+          -1085.1442809848161,
+          -2948.6367940889936,
           true
         ]
       ],
@@ -3746,13 +3821,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1143.482045480848,
-          -3063.4595759503682,
+          -1142.4098777372108,
+          -3162.4367940889933,
           true
         ],
         [
-          -1185.451574686874,
-          -3066.9345276455856,
+          -1260.7974721112093,
+          -3213.1805373228708,
           true
         ]
       ],
@@ -3766,13 +3841,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1134.0401139249161,
-          -3082.9949730295557,
+          -1118.4978202902942,
+          -3162.4367940889933,
           true
         ],
         [
-          -1195.8465643523448,
-          -3110.3148816331136,
+          -1284.709529558126,
+          -3283.1805373228708,
           true
         ]
       ],
@@ -3786,13 +3861,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -1053.7109587073478,
-          -3032.9949730295557,
+          -1057.6580838254617,
+          -3112.4367940889933,
           true
         ],
         [
-          -952.4556730664832,
-          -2926.5050104484762,
+          -958.50926602295817,
+          -3018.6367940889936,
           true
         ]
       ],
@@ -3806,13 +3881,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1011.0576686012491,
-          -3012.4342307986844,
+          -998.08367492420984,
+          -3154.6161219451214,
           true
         ],
         [
-          -1185.451574686874,
-          -3055.9358039824892,
+          -1253.12367492421,
+          -3221.0012094667427,
           true
         ]
       ],
@@ -3826,13 +3901,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1000.1994425568697,
-          -3020.9709042147756,
+          -988.75339421662477,
+          -3162.4367940889933,
           true
         ],
         [
-          -1197.2628588407922,
-          -3110.3148816331136,
+          -1262.4539556317952,
+          -3283.1805373228708,
           true
         ]
       ],
@@ -3846,13 +3921,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -942.44219725199594,
-          -2970.9709042147756,
+          -932.08367492420984,
+          -3112.4367940889933,
           true
         ],
         [
-          -922.773612748702,
-          -2782.9686105850815,
+          -932.08367492420984,
+          -2878.6367940889936,
           true
         ]
       ],
@@ -3866,13 +3941,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1007.9433903743818,
-          -3060.14145893136,
+          -1010.1236749242103,
+          -3212.8476928981559,
           true
         ],
         [
-          -1185.451574686874,
-          -3069.0768343150557,
+          -1253.12367492421,
+          -3232.7696385137083,
           true
         ]
       ],
@@ -3886,13 +3961,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -1007.9433903743818,
-          -3073.5063259809422,
+          -1010.1236749242103,
+          -3225.1676928981556,
           true
         ],
         [
-          -1186.4046327964129,
-          -3118.627718332189,
+          -1253.12367492421,
+          -3290.4496385137086,
           true
         ]
       ],
@@ -3906,13 +3981,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -939.99704756314316,
-          -3031.8191626800176,
+          -943.06306886360414,
+          -3182.4367940889933,
           true
         ],
         [
-          -926.32973595837871,
-          -2856.2679760410856,
+          -933.144280984816,
+          -2948.6367940889936,
           true
         ]
       ],
@@ -3926,13 +4001,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -866.525683520225,
-          -3059.09953269346,
+          -846.08367492421,
+          -3149.7718472454121,
           true
         ],
         [
-          -1185.451574686874,
-          -3070.1187605529558,
+          -1253.12367492421,
+          -3225.845484166452,
           true
         ]
       ],
@@ -3946,13 +4021,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -866.525683520225,
-          -3068.2839973646223,
+          -846.08367492421,
+          -3158.3426397654475,
           true
         ],
         [
-          -1186.4046327964129,
-          -3123.8500469485089,
+          -1253.12367492421,
+          -3287.2746916464166,
           true
         ]
       ],
@@ -3966,13 +4041,13 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -798.26168240107711,
-          -3031.8191626800176,
+          -780.08367492421,
+          -3112.4367940889933,
           true
         ],
         [
-          -782.57672195612656,
-          -2858.6195967401618,
+          -780.08367492421,
+          -2910.9946375703162,
           true
         ]
       ],
@@ -3986,13 +4061,13 @@
       "Stereotype": "Implementation",
       "RoutePoints": [
         [
-          -865.631769675306,
-          -3116.2579767178495,
+          -858.12367492421026,
+          -3221.048974471913,
           true
         ],
         [
-          -1186.4046327964129,
-          -3132.0629582322372,
+          -1253.12367492421,
+          -3295.7061704071157,
           true
         ]
       ],
@@ -4006,13 +4081,73 @@
       "Stereotype": "Association",
       "RoutePoints": [
         [
-          -792.30252950989609,
-          -3087.70943848556,
+          -785.50512771922376,
+          -3182.4367940889933,
           true
         ],
         [
-          -783.79874030331212,
-          -2925.3292000989377,
+          -780.68222212919636,
+          -2980.9946375703162,
+          true
+        ]
+      ],
+      "IsCreatedFromModelItem": true
+    },
+    {
+      "Id": 242,
+      "SourceId": 241,
+      "TargetId": 235,
+      "ZIndex": 220,
+      "Stereotype": "AssemblyReference",
+      "RoutePoints": [
+        [
+          -562.62893803475492,
+          -3599.8501983598717,
+          true
+        ],
+        [
+          -561.3622399733074,
+          -3579.2352117446985,
+          true
+        ]
+      ],
+      "IsCreatedFromModelItem": true
+    },
+    {
+      "Id": 247,
+      "SourceId": 246,
+      "TargetId": 36,
+      "ZIndex": 225,
+      "Stereotype": "Association",
+      "RoutePoints": [
+        [
+          -519.24176755512019,
+          -3613.3869043957661,
+          true
+        ],
+        [
+          -0.16930431151993197,
+          -2421.4552703125005,
+          true
+        ]
+      ],
+      "IsCreatedFromModelItem": true
+    },
+    {
+      "Id": 249,
+      "SourceId": 246,
+      "TargetId": 61,
+      "ZIndex": 227,
+      "Stereotype": "Association",
+      "RoutePoints": [
+        [
+          -515.37877560731238,
+          -3613.3869043957661,
+          true
+        ],
+        [
+          -4.03229625932776,
+          -2746.7099000003541,
           true
         ]
       ],
@@ -4438,6 +4573,71 @@
           "Tooltip": "public System2x2Model Model { get; }",
           "CanBeHidden": false,
           "Symbol": "{\"K\":\"Property\",\"N\":\"Model\",\"C\":{\"K\":\"NamedType\",\"N\":\"SystemOfEquations2x2\",\"C\":{\"K\":\"Namespace\",\"N\":\"Equations\",\"C\":{\"K\":\"Namespace\",\"N\":\"Algebra\",\"C\":{\"K\":\"Namespace\",\"N\":\"Numerics\",\"C\":{\"K\":\"Namespace\",\"N\":\"src\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion\",\"V\":\"1.0.0.0\"}}}}}}}}"
+        }
+      ]
+    },
+    {
+      "Id": 243,
+      "ConnectorId": 242,
+      "ZIndex": 221,
+      "AnchorKind": "Middle",
+      "AnchorVector": "0,0",
+      "Size": "79.5967,17.5",
+      "IsPinned": false,
+      "Entries": [
+        {
+          "TextColumn2": "<<references>>",
+          "CanBeHidden": false
+        }
+      ]
+    },
+    {
+      "Id": 248,
+      "ConnectorId": 247,
+      "ZIndex": 226,
+      "AnchorKind": "End",
+      "AnchorVector": "0,0",
+      "Size": "99.3667,17.5",
+      "IsPinned": false,
+      "Entries": [
+        {
+          "TextColumn1": "0..1",
+          "TextColumn2": "_curveRenderer",
+          "Tooltip": "private CurveRenderer2D? _curveRenderer",
+          "CanBeHidden": false,
+          "Symbol": "{\"K\":\"Field\",\"N\":\"_curveRenderer\",\"C\":{\"K\":\"NamedType\",\"N\":\"MainWindow\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}}"
+        }
+      ]
+    },
+    {
+      "Id": 250,
+      "ConnectorId": 249,
+      "ZIndex": 228,
+      "AnchorKind": "End",
+      "AnchorVector": "0,0",
+      "Size": "85.48,40.5",
+      "IsPinned": false,
+      "Entries": [
+        {
+          "TextColumn1": "0..1",
+          "TextColumn2": "_functionPlot",
+          "Tooltip": "private Plot2D? _functionPlot",
+          "CanBeHidden": false,
+          "Symbol": "{\"K\":\"Field\",\"N\":\"_functionPlot\",\"C\":{\"K\":\"NamedType\",\"N\":\"MainWindow\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}}"
+        },
+        {
+          "TextColumn1": "*",
+          "TextColumn2": "_gridPlots",
+          "Tooltip": "private readonly List<Plot2D> _gridPlots",
+          "CanBeHidden": false,
+          "Symbol": "{\"K\":\"Field\",\"N\":\"_gridPlots\",\"C\":{\"K\":\"NamedType\",\"N\":\"MainWindow\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}}"
+        },
+        {
+          "TextColumn1": "*",
+          "TextColumn2": "_axisPlots",
+          "Tooltip": "private readonly List<Plot2D> _axisPlots",
+          "CanBeHidden": false,
+          "Symbol": "{\"K\":\"Field\",\"N\":\"_axisPlots\",\"C\":{\"K\":\"NamedType\",\"N\":\"MainWindow\",\"C\":{\"K\":\"Namespace\",\"N\":\"Desktop\",\"C\":{\"K\":\"Namespace\",\"N\":\"Fluxion\",\"C\":{\"K\":\"Assembly\",\"N\":\"Fluxion.Desktop\",\"V\":\"1.0.0.0\"}}}}}"
         }
       ]
     }

--- a/src/Expressions/ExpressionEngine.cs
+++ b/src/Expressions/ExpressionEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Fluxion.src.Expressions;
 
@@ -66,7 +67,8 @@ public static class ExpressionEngine
         if (!IsSupportedAssignment(leftSide))
         {
             throw new ExpressionParseException(
-                "Use an expression, y = expression, or f(x) = expression",
+                "Use an expression, y = expression, z = expression, " +
+                "f(x) = expression, or f(x,y) = expression",
                 0);
         }
 
@@ -82,7 +84,7 @@ public static class ExpressionEngine
 
     private static bool IsSupportedAssignment(string leftSide)
     {
-        if (leftSide == "y")
+        if (leftSide is "y" or "z")
         {
             return true;
         }
@@ -96,10 +98,16 @@ public static class ExpressionEngine
             return false;
         }
 
-        string functionName = leftSide[..openParenthesis].Trim();
-        string parameter = leftSide[(openParenthesis + 1)..closeParenthesis].Trim();
+        string functionName =
+            leftSide[..openParenthesis].Trim();
 
-        if (parameter != "x" || functionName.Length == 0)
+        string parameters =
+            leftSide[(openParenthesis + 1)..closeParenthesis]
+                .Replace(" ", string.Empty);
+
+        if ((parameters != "x" &&
+             parameters != "x,y") ||
+            functionName.Length == 0)
         {
             return false;
         }
@@ -131,14 +139,32 @@ public sealed class CompiledExpression
 
     public string Source { get; }
 
-    public bool ContainsVariable => _root.ContainsVariable;
+    public bool ContainsX => _root.ContainsX;
 
-    public double Evaluate(double x = 0.0)
+    public bool ContainsY => _root.ContainsY;
+
+    public bool ContainsVariable =>
+        ContainsX || ContainsY;
+
+    public double Evaluate(
+        double x = 0.0,
+        double y = 0.0)
     {
-        return _root.Evaluate(x);
+        return _root.Evaluate(x, y);
     }
 
     public Func<double, double> ToFunction()
+    {
+        if (ContainsY)
+        {
+            throw new InvalidOperationException(
+                "This expression uses y and must be plotted as a 3D surface.");
+        }
+
+        return x => Evaluate(x, 0.0);
+    }
+
+    public Func<double, double, double> ToSurface()
     {
         return Evaluate;
     }
@@ -553,7 +579,14 @@ internal sealed class ExpressionParser
     {
         return identifier.Text switch
         {
-            "x" => new VariableExpressionNode(),
+            "x" =>
+                new VariableExpressionNode(
+                    ExpressionVariable.X),
+
+            "y" =>
+                new VariableExpressionNode(
+                    ExpressionVariable.Y),
+
             "pi" => new NumberExpressionNode(Math.PI),
             "e" => new NumberExpressionNode(Math.E),
             "tau" => new NumberExpressionNode(Math.Tau),
@@ -564,7 +597,8 @@ internal sealed class ExpressionParser
                     identifier.Position),
 
             _ => throw new ExpressionParseException(
-                $"Unknown identifier '{identifier.Text}'. Step 1 supports the variable x",
+                $"Unknown identifier '{identifier.Text}'. " +
+                "Fluxion currently supports the variables x and y",
                 identifier.Position)
         };
     }
@@ -599,8 +633,13 @@ internal sealed class ExpressionParser
 
 internal abstract class ExpressionNode
 {
-    public abstract bool ContainsVariable { get; }
-    public abstract double Evaluate(double x);
+    public abstract bool ContainsX { get; }
+
+    public abstract bool ContainsY { get; }
+
+    public abstract double Evaluate(
+        double x,
+        double y);
 }
 
 internal sealed class NumberExpressionNode : ExpressionNode
@@ -612,21 +651,52 @@ internal sealed class NumberExpressionNode : ExpressionNode
         _value = value;
     }
 
-    public override bool ContainsVariable => false;
+    public override bool ContainsX => false;
 
-    public override double Evaluate(double x)
+    public override bool ContainsY => false;
+
+    public override double Evaluate(
+        double x,
+        double y)
     {
         return _value;
     }
 }
 
+internal enum ExpressionVariable
+{
+    X,
+    Y
+}
+
 internal sealed class VariableExpressionNode : ExpressionNode
 {
-    public override bool ContainsVariable => true;
+    private readonly ExpressionVariable _variable;
 
-    public override double Evaluate(double x)
+    public VariableExpressionNode(
+        ExpressionVariable variable)
     {
-        return x;
+        _variable = variable;
+    }
+
+    public override bool ContainsX =>
+        _variable == ExpressionVariable.X;
+
+    public override bool ContainsY =>
+        _variable == ExpressionVariable.Y;
+
+    public override double Evaluate(
+        double x,
+        double y)
+    {
+        return _variable switch
+        {
+            ExpressionVariable.X => x,
+            ExpressionVariable.Y => y,
+
+            _ => throw new InvalidOperationException(
+                "Unknown expression variable.")
+        };
     }
 }
 
@@ -649,11 +719,18 @@ internal sealed class UnaryExpressionNode : ExpressionNode
         _operand = operand;
     }
 
-    public override bool ContainsVariable => _operand.ContainsVariable;
+    public override bool ContainsX =>
+        _operand.ContainsX;
 
-    public override double Evaluate(double x)
+    public override bool ContainsY =>
+        _operand.ContainsY;
+
+    public override double Evaluate(
+        double x,
+        double y)
     {
-        double value = _operand.Evaluate(x);
+        double value =
+            _operand.Evaluate(x, y);
 
         return _operator switch
         {
@@ -689,13 +766,23 @@ internal sealed class BinaryExpressionNode : ExpressionNode
         _right = right;
     }
 
-    public override bool ContainsVariable =>
-        _left.ContainsVariable || _right.ContainsVariable;
+    public override bool ContainsX =>
+        _left.ContainsX ||
+        _right.ContainsX;
 
-    public override double Evaluate(double x)
+    public override bool ContainsY =>
+        _left.ContainsY ||
+        _right.ContainsY;
+
+    public override double Evaluate(
+        double x,
+        double y)
     {
-        double leftValue = _left.Evaluate(x);
-        double rightValue = _right.Evaluate(x);
+        double leftValue =
+            _left.Evaluate(x, y);
+
+        double rightValue =
+            _right.Evaluate(x, y);
 
         return _operator switch
         {
@@ -722,32 +809,32 @@ internal sealed class FunctionExpressionNode : ExpressionNode
         _arguments = arguments;
     }
 
-    public override bool ContainsVariable
+    public override bool ContainsX =>
+        _arguments.Any(argument =>
+            argument.ContainsX);
+
+    public override bool ContainsY =>
+        _arguments.Any(argument =>
+            argument.ContainsY);
+
+    public override double Evaluate(
+        double x,
+        double y)
     {
-        get
+        var values =
+            new double[_arguments.Count];
+
+        for (int index = 0;
+             index < _arguments.Count;
+             index++)
         {
-            foreach (ExpressionNode argument in _arguments)
-            {
-                if (argument.ContainsVariable)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-    }
-
-    public override double Evaluate(double x)
-    {
-        var values = new double[_arguments.Count];
-
-        for (int index = 0; index < _arguments.Count; index++)
-        {
-            values[index] = _arguments[index].Evaluate(x);
+            values[index] =
+                _arguments[index].Evaluate(x, y);
         }
 
-        return FunctionCatalog.Evaluate(_name, values);
+        return FunctionCatalog.Evaluate(
+            _name,
+            values);
     }
 }
 

--- a/src/Plotting/Sampling/FunctionSegmentSampler.cs
+++ b/src/Plotting/Sampling/FunctionSegmentSampler.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace Fluxion.src.Plotting.Sampling;
+
+/// <summary>
+/// Samples a one-variable function and separates it into independent
+/// curve segments so the renderer never connects across discontinuities.
+/// </summary>
+public static class FunctionSegmentSampler
+{
+    public static FunctionSampleResult Sample(
+        Func<double, double> function,
+        double xMinimum,
+        double xMaximum,
+        int sampleCount,
+        FunctionSamplingOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+
+        if (!double.IsFinite(xMinimum) ||
+            !double.IsFinite(xMaximum))
+        {
+            throw new ArgumentException(
+                "The sampling range must contain finite values.");
+        }
+
+        if (xMinimum >= xMaximum)
+        {
+            throw new ArgumentException(
+                "X minimum must be smaller than X maximum.");
+        }
+
+        sampleCount = Math.Max(2, sampleCount);
+        options ??= new FunctionSamplingOptions();
+
+        var samples = new SamplePoint[sampleCount];
+
+        double step =
+            (xMaximum - xMinimum) /
+            (sampleCount - 1);
+
+        int invalidSampleCount = 0;
+
+        for (int index = 0; index < sampleCount; index++)
+        {
+            double x = index == sampleCount - 1
+                ? xMaximum
+                : xMinimum + (index * step);
+
+            samples[index] =
+                EvaluateSafely(
+                    function,
+                    x,
+                    options.MaximumAbsoluteY);
+
+            if (!samples[index].IsValid)
+            {
+                invalidSampleCount++;
+            }
+        }
+
+        double robustScale =
+            CalculateRobustScale(samples);
+
+        var segments =
+            new List<IReadOnlyList<Vector2>>();
+
+        var currentSegment =
+            new List<Vector2>();
+
+        int breakCount = 0;
+
+        for (int index = 0; index < samples.Length; index++)
+        {
+            SamplePoint current = samples[index];
+
+            if (!current.IsValid)
+            {
+                if (FlushSegment(currentSegment, segments))
+                {
+                    breakCount++;
+                }
+
+                continue;
+            }
+
+            if (currentSegment.Count == 0)
+            {
+                currentSegment.Add(ToVector(current));
+                continue;
+            }
+
+            SamplePoint previous = samples[index - 1];
+
+            if (!previous.IsValid)
+            {
+                currentSegment.Add(ToVector(current));
+                continue;
+            }
+
+            IntervalInspection inspection =
+                InspectInterval(
+                    function,
+                    previous,
+                    current,
+                    robustScale,
+                    options);
+
+            invalidSampleCount += inspection.InvalidProbeCount;
+
+            if (inspection.ShouldBreak)
+            {
+                FlushSegment(currentSegment, segments);
+                breakCount++;
+                currentSegment.Add(ToVector(current));
+                continue;
+            }
+
+            currentSegment.Add(ToVector(current));
+        }
+
+        FlushSegment(currentSegment, segments);
+
+        return new FunctionSampleResult(
+            segments,
+            breakCount,
+            invalidSampleCount,
+            robustScale);
+    }
+
+    private static IntervalInspection InspectInterval(
+        Func<double, double> function,
+        SamplePoint left,
+        SamplePoint right,
+        double robustScale,
+        FunctionSamplingOptions options)
+    {
+        double width = right.X - left.X;
+
+        var probes = new[]
+        {
+            left,
+            EvaluateSafely(
+                function,
+                left.X + (width * 0.25),
+                options.MaximumAbsoluteY),
+            EvaluateSafely(
+                function,
+                left.X + (width * 0.50),
+                options.MaximumAbsoluteY),
+            EvaluateSafely(
+                function,
+                left.X + (width * 0.75),
+                options.MaximumAbsoluteY),
+            right
+        };
+
+        int invalidProbeCount =
+            probes.Count(point => !point.IsValid);
+
+        if (invalidProbeCount > 0)
+        {
+            return new IntervalInspection(
+                true,
+                invalidProbeCount);
+        }
+
+        double endpointMaximum =
+            Math.Max(
+                Math.Abs(left.Y),
+                Math.Abs(right.Y));
+
+        double intervalMaximum =
+            probes.Max(point => Math.Abs(point.Y));
+
+        bool interiorSpike =
+            intervalMaximum >
+            Math.Max(
+                robustScale *
+                options.InteriorSpikeScaleMultiplier,
+                endpointMaximum *
+                options.InteriorSpikeEndpointMultiplier);
+
+        bool largeSignFlip = false;
+
+        for (int index = 1; index < probes.Length; index++)
+        {
+            double previousValue = probes[index - 1].Y;
+            double currentValue = probes[index].Y;
+
+            bool signsDiffer =
+                Math.Sign(previousValue) !=
+                Math.Sign(currentValue);
+
+            bool bothLarge =
+                Math.Min(
+                    Math.Abs(previousValue),
+                    Math.Abs(currentValue))
+                >
+                robustScale *
+                options.LargeSignFlipMultiplier;
+
+            if (signsDiffer && bothLarge)
+            {
+                largeSignFlip = true;
+                break;
+            }
+        }
+
+        double totalVariation = 0.0;
+
+        for (int index = 1; index < probes.Length; index++)
+        {
+            totalVariation +=
+                Math.Abs(
+                    probes[index].Y -
+                    probes[index - 1].Y);
+        }
+
+        double endpointChange =
+            Math.Abs(right.Y - left.Y);
+
+        bool excessiveVariation =
+            totalVariation >
+                robustScale *
+                options.TotalVariationScaleMultiplier
+            &&
+            totalVariation >
+                Math.Max(1.0, endpointChange) *
+                options.TotalVariationEndpointMultiplier;
+
+        return new IntervalInspection(
+            interiorSpike ||
+            largeSignFlip ||
+            excessiveVariation,
+            0);
+    }
+
+    private static SamplePoint EvaluateSafely(
+        Func<double, double> function,
+        double x,
+        double maximumAbsoluteY)
+    {
+        try
+        {
+            double y = function(x);
+
+            bool valid =
+                double.IsFinite(y) &&
+                Math.Abs(y) <= maximumAbsoluteY;
+
+            return new SamplePoint(x, y, valid);
+        }
+        catch
+        {
+            return new SamplePoint(
+                x,
+                double.NaN,
+                false);
+        }
+    }
+
+    private static double CalculateRobustScale(
+        IReadOnlyList<SamplePoint> samples)
+    {
+        double[] magnitudes =
+            samples
+                .Where(point => point.IsValid)
+                .Select(point => Math.Abs(point.Y))
+                .OrderBy(value => value)
+                .ToArray();
+
+        if (magnitudes.Length == 0)
+        {
+            return 1.0;
+        }
+
+        int percentileIndex =
+            (int)Math.Floor(
+                (magnitudes.Length - 1) * 0.80);
+
+        return Math.Max(
+            1.0e-6,
+            magnitudes[percentileIndex]);
+    }
+
+    private static bool FlushSegment(
+        List<Vector2> currentSegment,
+        List<IReadOnlyList<Vector2>> segments)
+    {
+        if (currentSegment.Count >= 2)
+        {
+            segments.Add(currentSegment.ToArray());
+            currentSegment.Clear();
+            return true;
+        }
+
+        currentSegment.Clear();
+        return false;
+    }
+
+    private static Vector2 ToVector(SamplePoint point)
+    {
+        return new Vector2(
+            (float)point.X,
+            (float)point.Y);
+    }
+
+    private readonly record struct SamplePoint(
+        double X,
+        double Y,
+        bool IsValid);
+
+    private readonly record struct IntervalInspection(
+        bool ShouldBreak,
+        int InvalidProbeCount);
+}
+
+public sealed class FunctionSamplingOptions
+{
+    public double MaximumAbsoluteY { get; init; } =
+        1_000_000.0;
+
+    public double InteriorSpikeScaleMultiplier { get; init; } =
+        8.0;
+
+    public double InteriorSpikeEndpointMultiplier { get; init; } =
+        6.0;
+
+    public double LargeSignFlipMultiplier { get; init; } =
+        4.0;
+
+    public double TotalVariationScaleMultiplier { get; init; } =
+        20.0;
+
+    public double TotalVariationEndpointMultiplier { get; init; } =
+        4.0;
+}
+
+public sealed class FunctionSampleResult
+{
+    public FunctionSampleResult(
+        IReadOnlyList<IReadOnlyList<Vector2>> segments,
+        int breakCount,
+        int invalidSampleCount,
+        double robustScale)
+    {
+        Segments = segments;
+        BreakCount = breakCount;
+        InvalidSampleCount = invalidSampleCount;
+        RobustScale = robustScale;
+    }
+
+    public IReadOnlyList<IReadOnlyList<Vector2>> Segments { get; }
+
+    public int BreakCount { get; }
+
+    public int InvalidSampleCount { get; }
+
+    public double RobustScale { get; }
+}

--- a/src/Rendering/Draw/Axis3DRenderer.cs
+++ b/src/Rendering/Draw/Axis3DRenderer.cs
@@ -1,167 +1,437 @@
-﻿// Fluxion.Rendering/Draw/Axis3DRenderer.cs
 using System;
 using System.Collections.Generic;
+
 using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
 
-namespace Fluxion.src.Rendering.Draw
+namespace Fluxion.src.Rendering.Draw;
+
+/// <summary>
+/// Draws mathematical X, Y, and Z axes plus an X/Y ground grid.
+///
+/// World-axis mapping:
+/// mathematical X -> world X
+/// mathematical Y -> world Z
+/// mathematical Z -> world Y
+///
+/// This keeps world Y as the vertical direction for the orbit camera.
+/// </summary>
+public sealed class Axis3DRenderer : IDisposable
 {
-    /// <summary>
-    /// Minimal 3D axes + grid (XY plane) renderer using OpenGL lines.
-    /// - Draws X (red), Y (green), Z (blue) axes through the origin.
-    /// - Draws a gray XY grid at Z = 0.
-    /// </summary>
-    public sealed class Axis3DRenderer : IDisposable
+    private readonly int _vertexArray;
+    private readonly int _vertexBuffer;
+    private readonly int _program;
+    private readonly int _mvpLocation;
+
+    private readonly int _axisVertexCount;
+    private readonly int _gridFirstVertex;
+    private readonly int _gridVertexCount;
+
+    public Axis3DRenderer(
+        int halfExtent = 10,
+        float step = 1.0f)
     {
-        private readonly int _vao; //Vertex Array Object
-        private readonly int _vbo; //Vertex Buffer Object
-        private readonly int _program;
-        private readonly int _uMvpLoc;// Uniform location for MVP matrix        
-        private readonly int _vertexTCount;
+        halfExtent =
+            Math.Max(
+                1,
+                halfExtent);
 
-        public Axis3DRenderer(int halfExtent = 10, float step = 1f)
+        var axisData =
+            new List<float>(64);
+
+        var gridData =
+            new List<float>(1024);
+
+        var xColor =
+            (R: 1.0f, G: 0.25f, B: 0.25f);
+
+        var yColor =
+            (R: 0.25f, G: 1.0f, B: 0.35f);
+
+        var zColor =
+            (R: 0.25f, G: 0.50f, B: 1.0f);
+
+        var gridColor =
+            (R: 0.25f, G: 0.25f, B: 0.30f);
+
+        /*
+         * Mathematical X axis: world X.
+         */
+        PushLine(
+            axisData,
+            new Vector3(
+                -halfExtent,
+                0,
+                0),
+            new Vector3(
+                halfExtent,
+                0,
+                0),
+            xColor);
+
+        /*
+         * Mathematical Y axis: world Z.
+         */
+        PushLine(
+            axisData,
+            new Vector3(
+                0,
+                0,
+                -halfExtent),
+            new Vector3(
+                0,
+                0,
+                halfExtent),
+            yColor);
+
+        /*
+         * Mathematical Z axis: world Y.
+         */
+        PushLine(
+            axisData,
+            new Vector3(
+                0,
+                -halfExtent,
+                0),
+            new Vector3(
+                0,
+                halfExtent,
+                0),
+            zColor);
+
+        if (step > 0.0f)
         {
-            // --- Build geometry (interleaved: pos.xyz, color.rgb) ---
-            var data = new List<float>(1024);
-
-            // Colors
-            var red   = (1f, 0f, 0f);
-            var green = (0f, 1f, 0f);
-            var blue  = (0f, 0f, 1f);
-            var grid  = (0.25f, 0.25f, 0.30f);
-
-            // Axes lines (-L..+L)
-            int L = System.Math.Max(1, halfExtent);
-
-            // X axis
-            PushLine(data, new Vector3(-L, 0, 0), new Vector3(+L, 0, 0), red);
-            // Y axis
-            PushLine(data, new Vector3(0, -L, 0), new Vector3(0, +L, 0), green);
-            // Z axis
-            PushLine(data, new Vector3(0, 0, -L), new Vector3(0, 0, +L), blue);
-
-            // XY grid (at Z = 0)
-            if (step > 0f)
+            /*
+             * X/Y mathematical grid lies on world Y = 0,
+             * which is the world X/Z plane.
+             */
+            for (float x = -halfExtent;
+                 x <= halfExtent + 0.0001f;
+                 x += step)
             {
-                for (float x = -L; x <= L + 1e-4f; x += step)
-                    PushLine(data, new Vector3(x, -L, 0), new Vector3(x, +L, 0), grid);
-
-                for (float y = -L; y <= L + 1e-4f; y += step)
-                    PushLine(data, new Vector3(-L, y, 0), new Vector3(+L, y, 0), grid);
+                PushLine(
+                    gridData,
+                    new Vector3(
+                        x,
+                        0,
+                        -halfExtent),
+                    new Vector3(
+                        x,
+                        0,
+                        halfExtent),
+                    gridColor);
             }
 
-            _vertexTCount = data.Count / 6;
-
-            // --- GL objects ---
-            _vao = GL.GenVertexArray();
-            _vbo = GL.GenBuffer();
-            GL.BindVertexArray(_vao);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _vbo);
-            GL.BufferData(BufferTarget.ArrayBuffer, data.Count * sizeof(float), data.ToArray(), BufferUsageHint.StaticDraw);
-
-            // layout(location=0) vec3 aPos;
-            GL.EnableVertexAttribArray(0);
-            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 6 * sizeof(float), 0);
-            // layout(location=1) vec3 aColor;
-            GL.EnableVertexAttribArray(1);
-            GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 6 * sizeof(float), 3 * sizeof(float));
-
-            GL.BindVertexArray(0);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            // --- Shader program ---
-            var vs = @"
-                #version 330 core
-                layout(location=0) in vec3 aPos;
-                layout(location=1) in vec3 aColor;
-                uniform mat4 uMVP;
-                out vec3 vColor;
-                void main(){
-                    vColor = aColor;
-                    gl_Position = uMVP * vec4(aPos, 1.0);
-                }";
-                            var fs = @"
-                #version 330 core
-                in vec3 vColor;
-                out vec4 FragColor;
-                void main(){
-                    FragColor = vec4(vColor, 1.0);
-                }";
-            _program = CreateProgram(vs, fs);
-            _uMvpLoc = GL.GetUniformLocation(_program, "uMVP");
-        }
-
-        /// <summary>Draws axes+grid. Accepts the combined MVP matrix.</summary>
-        public void Draw(Matrix4 mvp)
-        {
-            GL.UseProgram(_program);
-            GL.UniformMatrix4(_uMvpLoc, false, ref mvp);
-
-            // slightly thicker lines for axes; grid lines are in the same batch,
-            // so set a uniform width that looks decent overall
-            GL.LineWidth(1.2f);
-
-            GL.BindVertexArray(_vao);
-            GL.DrawArrays(PrimitiveType.Lines, 0, _vertexTCount);
-            GL.BindVertexArray(0);
-
-            GL.UseProgram(0);
-        }
-
-        /// <summary>Back-compat with earlier call sites.</summary>
-        public void DrawAxes(Matrix4 mvp) => Draw(mvp);
-
-        public void Dispose()
-        {
-            if (_vbo != 0) GL.DeleteBuffer(_vbo);
-            if (_vao != 0) GL.DeleteVertexArray(_vao);
-            if (_program != 0) GL.DeleteProgram(_program);
-        }
-
-        // ---- helpers ----
-        private static void PushLine(List<float> dst, Vector3 a, Vector3 b, (float r, float g, float bcol) c)
-        {
-            // A
-            dst.Add(a.X); dst.Add(a.Y); dst.Add(a.Z);
-            dst.Add(c.r); dst.Add(c.g); dst.Add(c.bcol);
-            // B
-            dst.Add(b.X); dst.Add(b.Y); dst.Add(b.Z);
-            dst.Add(c.r); dst.Add(c.g); dst.Add(c.bcol);
-        }
-
-        private static int CreateProgram(string vsSrc, string fsSrc)
-        {
-            int vs = CompileShader(ShaderType.VertexShader, vsSrc);
-            int fs = CompileShader(ShaderType.FragmentShader, fsSrc);
-            int prog = GL.CreateProgram();
-            GL.AttachShader(prog, vs);
-            GL.AttachShader(prog, fs);
-            GL.LinkProgram(prog);
-            GL.GetProgram(prog, GetProgramParameterName.LinkStatus, out var ok);
-            if (ok == 0)
+            for (float y = -halfExtent;
+                 y <= halfExtent + 0.0001f;
+                 y += step)
             {
-                var log = GL.GetProgramInfoLog(prog);
-                GL.DeleteShader(vs); GL.DeleteShader(fs); GL.DeleteProgram(prog);
-                throw new Exception("Axis3DRenderer link error: " + log);
+                PushLine(
+                    gridData,
+                    new Vector3(
+                        -halfExtent,
+                        0,
+                        y),
+                    new Vector3(
+                        halfExtent,
+                        0,
+                        y),
+                    gridColor);
             }
-            GL.DetachShader(prog, vs); GL.DetachShader(prog, fs);
-            GL.DeleteShader(vs); GL.DeleteShader(fs);
-            return prog;
         }
 
-        private static int CompileShader(ShaderType type, string src)
-        {
-            int sh = GL.CreateShader(type);
-            GL.ShaderSource(sh, src);
-            GL.CompileShader(sh);
-            GL.GetShader(sh, ShaderParameter.CompileStatus, out var ok);
-            if (ok == 0)
+        _axisVertexCount =
+            axisData.Count / 6;
+
+        _gridFirstVertex =
+            _axisVertexCount;
+
+        _gridVertexCount =
+            gridData.Count / 6;
+
+        axisData.AddRange(
+            gridData);
+
+        _vertexArray =
+            GL.GenVertexArray();
+
+        _vertexBuffer =
+            GL.GenBuffer();
+
+        GL.BindVertexArray(
+            _vertexArray);
+
+        GL.BindBuffer(
+            BufferTarget.ArrayBuffer,
+            _vertexBuffer);
+
+        GL.BufferData(
+            BufferTarget.ArrayBuffer,
+            axisData.Count *
+            sizeof(float),
+            axisData.ToArray(),
+            BufferUsageHint.StaticDraw);
+
+        GL.EnableVertexAttribArray(0);
+
+        GL.VertexAttribPointer(
+            0,
+            3,
+            VertexAttribPointerType.Float,
+            false,
+            6 * sizeof(float),
+            0);
+
+        GL.EnableVertexAttribArray(1);
+
+        GL.VertexAttribPointer(
+            1,
+            3,
+            VertexAttribPointerType.Float,
+            false,
+            6 * sizeof(float),
+            3 * sizeof(float));
+
+        GL.BindVertexArray(0);
+        GL.BindBuffer(
+            BufferTarget.ArrayBuffer,
+            0);
+
+        const string vertexShaderSource = """
+            #version 330 core
+
+            layout(location = 0) in vec3 position;
+            layout(location = 1) in vec3 color;
+
+            uniform mat4 uMVP;
+
+            out vec3 vertexColor;
+
+            void main()
             {
-                var log = GL.GetShaderInfoLog(sh);
-                GL.DeleteShader(sh);
-                throw new Exception($"Axis3DRenderer {type} compile error: {log}");
+                vertexColor = color;
+
+                gl_Position =
+                    uMVP *
+                    vec4(position, 1.0);
             }
-            return sh;
+            """;
+
+        const string fragmentShaderSource = """
+            #version 330 core
+
+            in vec3 vertexColor;
+
+            out vec4 fragmentColor;
+
+            void main()
+            {
+                fragmentColor =
+                    vec4(vertexColor, 1.0);
+            }
+            """;
+
+        _program =
+            CreateProgram(
+                vertexShaderSource,
+                fragmentShaderSource);
+
+        _mvpLocation =
+            GL.GetUniformLocation(
+                _program,
+                "uMVP");
+    }
+
+    public void Draw(
+        Matrix4 mvp)
+    {
+        Draw(
+            mvp,
+            showAxes: true,
+            showGrid: true);
+    }
+
+    public void Draw(
+        Matrix4 mvp,
+        bool showAxes,
+        bool showGrid)
+    {
+        if (!showAxes &&
+            !showGrid)
+        {
+            return;
         }
+
+        GL.UseProgram(_program);
+
+        GL.UniformMatrix4(
+            _mvpLocation,
+            false,
+            ref mvp);
+
+        GL.BindVertexArray(
+            _vertexArray);
+
+        if (showGrid &&
+            _gridVertexCount > 0)
+        {
+            GL.LineWidth(1.0f);
+
+            GL.DrawArrays(
+                PrimitiveType.Lines,
+                _gridFirstVertex,
+                _gridVertexCount);
+        }
+
+        if (showAxes &&
+            _axisVertexCount > 0)
+        {
+            GL.LineWidth(2.0f);
+
+            GL.DrawArrays(
+                PrimitiveType.Lines,
+                0,
+                _axisVertexCount);
+        }
+
+        GL.BindVertexArray(0);
+        GL.UseProgram(0);
+    }
+
+    public void DrawAxes(
+        Matrix4 mvp)
+    {
+        Draw(
+            mvp,
+            showAxes: true,
+            showGrid: false);
+    }
+
+    public void Dispose()
+    {
+        GL.DeleteBuffer(
+            _vertexBuffer);
+
+        GL.DeleteVertexArray(
+            _vertexArray);
+
+        GL.DeleteProgram(
+            _program);
+    }
+
+    private static void PushLine(
+        ICollection<float> destination,
+        Vector3 start,
+        Vector3 end,
+        (float R, float G, float B) color)
+    {
+        destination.Add(start.X);
+        destination.Add(start.Y);
+        destination.Add(start.Z);
+
+        destination.Add(color.R);
+        destination.Add(color.G);
+        destination.Add(color.B);
+
+        destination.Add(end.X);
+        destination.Add(end.Y);
+        destination.Add(end.Z);
+
+        destination.Add(color.R);
+        destination.Add(color.G);
+        destination.Add(color.B);
+    }
+
+    private static int CreateProgram(
+        string vertexShaderSource,
+        string fragmentShaderSource)
+    {
+        int vertexShader =
+            CompileShader(
+                ShaderType.VertexShader,
+                vertexShaderSource);
+
+        int fragmentShader =
+            CompileShader(
+                ShaderType.FragmentShader,
+                fragmentShaderSource);
+
+        int program =
+            GL.CreateProgram();
+
+        GL.AttachShader(
+            program,
+            vertexShader);
+
+        GL.AttachShader(
+            program,
+            fragmentShader);
+
+        GL.LinkProgram(program);
+
+        GL.GetProgram(
+            program,
+            GetProgramParameterName.LinkStatus,
+            out int linkSucceeded);
+
+        string linkLog =
+            GL.GetProgramInfoLog(program);
+
+        GL.DetachShader(
+            program,
+            vertexShader);
+
+        GL.DetachShader(
+            program,
+            fragmentShader);
+
+        GL.DeleteShader(
+            vertexShader);
+
+        GL.DeleteShader(
+            fragmentShader);
+
+        if (linkSucceeded == 0)
+        {
+            GL.DeleteProgram(program);
+
+            throw new InvalidOperationException(
+                "Axis3DRenderer program link failed: " +
+                linkLog);
+        }
+
+        return program;
+    }
+
+    private static int CompileShader(
+        ShaderType shaderType,
+        string source)
+    {
+        int shader =
+            GL.CreateShader(shaderType);
+
+        GL.ShaderSource(
+            shader,
+            source);
+
+        GL.CompileShader(shader);
+
+        GL.GetShader(
+            shader,
+            ShaderParameter.CompileStatus,
+            out int compileSucceeded);
+
+        if (compileSucceeded == 0)
+        {
+            string log =
+                GL.GetShaderInfoLog(shader);
+
+            GL.DeleteShader(shader);
+
+            throw new InvalidOperationException(
+                $"Axis3DRenderer {shaderType} compilation failed: {log}");
+        }
+
+        return shader;
     }
 }

--- a/src/Rendering/Draw/SurfaceRenderer.cs
+++ b/src/Rendering/Draw/SurfaceRenderer.cs
@@ -1,152 +1,386 @@
-﻿//Fuxion/Fluxion.Rendering/Draw/SurfaceRenderer.cs
+using System;
+
+using Fluxion.src.Rendering.Visualize3D;
 
 using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
-using System;
-using Fluxion.src.Rendering.Visualize3D;
 
-namespace Fluxion.src.Rendering.Draw
+namespace Fluxion.src.Rendering.Draw;
+
+public sealed class SurfaceRenderer : IDisposable
 {
-   
+    private readonly int _vao;
+    private readonly int _positionBuffer;
+    private readonly int _normalBuffer;
+    private readonly int _elementBuffer;
+    private readonly int _program;
 
-    public sealed class SurfaceRenderer : IDisposable
+    private readonly int _mvpLocation;
+    private readonly int _modelLocation;
+
+    private int _elementCount;
+    private bool _isLineStrip;
+    private bool _hasMesh;
+
+    private const string VertexShaderSource = """
+        #version 330 core
+
+        layout(location = 0) in vec3 inPosition;
+        layout(location = 1) in vec3 inNormal;
+
+        uniform mat4 uMVP;
+        uniform mat4 uModel;
+
+        out vec3 normal;
+
+        void main()
+        {
+            gl_Position =
+                uMVP *
+                vec4(inPosition, 1.0);
+
+            normal =
+                mat3(uModel) *
+                inNormal;
+        }
+        """;
+
+    private const string FragmentShaderSource = """
+        #version 330 core
+
+        in vec3 normal;
+
+        out vec4 fragmentColor;
+
+        uniform vec3 uLightDirection =
+            normalize(vec3(0.5, 1.0, 0.3));
+
+        uniform vec3 uBaseColor =
+            vec3(0.2, 0.6, 1.0);
+
+        void main()
+        {
+            float lightAmount =
+                max(
+                    dot(
+                        normalize(normal),
+                        normalize(uLightDirection)),
+                    0.0);
+
+            vec3 color =
+                uBaseColor *
+                (0.35 + (0.65 * lightAmount));
+
+            fragmentColor =
+                vec4(color, 1.0);
+        }
+        """;
+
+    public SurfaceRenderer()
     {
-        private int vao;      // Vertex Array Object
-        private int vboPos;   // Vertex Buffer Object - positions
-        private int vboNrm;   // Vertex Buffer Object - normals
-        private int ebo;      // Element Buffer Object (indices)
-        private int program;  // Compiled shader program
+        _program =
+            CreateProgram(
+                VertexShaderSource,
+                FragmentShaderSource);
 
-        private int indexCount;
-        private bool isLineStrip;
+        _mvpLocation =
+            GL.GetUniformLocation(
+                _program,
+                "uMVP");
 
-        private const string VS = @"
-            #version 330 core
-            layout(location=0) in vec3 inPos;
-            layout(location=1) in vec3 inNrm;
-            uniform mat4 uMVP;
-            uniform mat4 uModel;
-            out vec3 vNrm;
-            void main(){
-            gl_Position = uMVP * vec4(inPos, 1.0);
-            vNrm = mat3(uModel) * inNrm;
-            }";
-        private const string FS = @"
-            #version 330 core
-            in vec3 vNrm;
-            out vec4 FragColor;
-            uniform vec3 uLightDir = normalize(vec3(0.5, 1.0, 0.3));
-            uniform vec3 uBase = vec3(0.2, 0.6, 1.0);
-                void main(){
-            float ndl = max(dot(normalize(vNrm), normalize(uLightDir)), 0.0);
-             vec3 col = uBase * (0.35 + 0.65 * ndl);
-             FragColor = vec4(col, 1.0);
-            }";
+        _modelLocation =
+            GL.GetUniformLocation(
+                _program,
+                "uModel");
 
-        public SurfaceRenderer()
+        _vao =
+            GL.GenVertexArray();
+
+        _positionBuffer =
+            GL.GenBuffer();
+
+        _normalBuffer =
+            GL.GenBuffer();
+
+        _elementBuffer =
+            GL.GenBuffer();
+    }
+
+    public void Upload(
+        Mesh3D mesh,
+        bool wireframeAsLines = false)
+    {
+        ArgumentNullException.ThrowIfNull(mesh);
+
+        _isLineStrip =
+            wireframeAsLines &&
+            mesh.Indices.Length == 0;
+
+        GL.BindVertexArray(_vao);
+
+        GL.BindBuffer(
+            BufferTarget.ArrayBuffer,
+            _positionBuffer);
+
+        GL.BufferData(
+            BufferTarget.ArrayBuffer,
+            mesh.Positions.Length *
+            3 * sizeof(float),
+            mesh.Positions,
+            BufferUsageHint.StaticDraw);
+
+        GL.EnableVertexAttribArray(0);
+
+        GL.VertexAttribPointer(
+            0,
+            3,
+            VertexAttribPointerType.Float,
+            false,
+            3 * sizeof(float),
+            0);
+
+        if (mesh.Normals.Length ==
+            mesh.Positions.Length)
         {
-            program = Compile(VS, FS);
-            vao = GL.GenVertexArray();
-            vboPos = GL.GenBuffer();
-            vboNrm = GL.GenBuffer();
-            ebo = GL.GenBuffer();
+            GL.BindBuffer(
+                BufferTarget.ArrayBuffer,
+                _normalBuffer);
+
+            GL.BufferData(
+                BufferTarget.ArrayBuffer,
+                mesh.Normals.Length *
+                3 * sizeof(float),
+                mesh.Normals,
+                BufferUsageHint.StaticDraw);
+
+            GL.EnableVertexAttribArray(1);
+
+            GL.VertexAttribPointer(
+                1,
+                3,
+                VertexAttribPointerType.Float,
+                false,
+                3 * sizeof(float),
+                0);
+        }
+        else
+        {
+            /*
+             * A disabled generic vertex attribute uses its
+             * current constant value.
+             */
+            GL.DisableVertexAttribArray(1);
+            GL.VertexAttrib3(
+                1,
+                0.0f,
+                1.0f,
+                0.0f);
         }
 
-        public void Upload(Mesh3D mesh, bool wireframeAsLines = false)
+        if (mesh.Indices.Length > 0)
         {
-            isLineStrip = wireframeAsLines && mesh.Indices.Length == 0 && mesh.Normals.Length == 0;
+            GL.BindBuffer(
+                BufferTarget.ElementArrayBuffer,
+                _elementBuffer);
 
-            GL.BindVertexArray(vao);
+            GL.BufferData(
+                BufferTarget.ElementArrayBuffer,
+                mesh.Indices.Length *
+                sizeof(int),
+                mesh.Indices,
+                BufferUsageHint.StaticDraw);
 
-            // Positions
-            GL.BindBuffer(BufferTarget.ArrayBuffer, vboPos);
-            GL.BufferData(BufferTarget.ArrayBuffer, mesh.Positions.Length * 3 * sizeof(float), mesh.Positions, BufferUsageHint.StaticDraw);
-            GL.EnableVertexAttribArray(0);
-            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 0, 0);
-
-            // Normals (optional for polylines)
-            if (mesh.Normals.Length == mesh.Positions.Length)
-            {
-                GL.BindBuffer(BufferTarget.ArrayBuffer, vboNrm);
-                GL.BufferData(BufferTarget.ArrayBuffer, mesh.Normals.Length * 3 * sizeof(float), mesh.Normals, BufferUsageHint.StaticDraw);
-                GL.EnableVertexAttribArray(1);
-                GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 0, 0);
-            }
-            else
-            {
-                GL.DisableVertexAttribArray(1);
-            }
-
-            // Indices
-            if (mesh.Indices.Length > 0)
-            {
-                GL.BindBuffer(BufferTarget.ElementArrayBuffer, ebo);
-                GL.BufferData(BufferTarget.ElementArrayBuffer, mesh.Indices.Length * sizeof(int), mesh.Indices, BufferUsageHint.StaticDraw);
-                indexCount = mesh.Indices.Length;
-            }
-            else
-            {
-                indexCount = mesh.Positions.Length; // for line strip
-            }
-
-            GL.BindVertexArray(0);
+            _elementCount =
+                mesh.Indices.Length;
+        }
+        else
+        {
+            _elementCount =
+                mesh.Positions.Length;
         }
 
-        public void Draw(Matrix4 mvp, Matrix4 model, bool wireframe)
+        GL.BindVertexArray(0);
+        GL.BindBuffer(
+            BufferTarget.ArrayBuffer,
+            0);
+
+        _hasMesh =
+            _elementCount > 0;
+    }
+
+    public void Draw(
+        Matrix4 mvp,
+        Matrix4 model,
+        bool wireframe)
+    {
+        if (!_hasMesh)
         {
-            GL.UseProgram(program);
-            GL.UniformMatrix4(GL.GetUniformLocation(program, "uMVP"), false, ref mvp);
-            GL.UniformMatrix4(GL.GetUniformLocation(program, "uModel"), false, ref model);
+            return;
+        }
 
-            GL.BindVertexArray(vao);
+        GL.UseProgram(_program);
 
-            if (isLineStrip)
+        GL.UniformMatrix4(
+            _mvpLocation,
+            false,
+            ref mvp);
+
+        GL.UniformMatrix4(
+            _modelLocation,
+            false,
+            ref model);
+
+        GL.BindVertexArray(_vao);
+
+        if (_isLineStrip)
+        {
+            GL.LineWidth(2.0f);
+
+            GL.DrawArrays(
+                PrimitiveType.LineStrip,
+                0,
+                _elementCount);
+        }
+        else
+        {
+            /*
+             * The index buffer contains triangles. Wireframe mode
+             * must still draw triangles while PolygonMode converts
+             * their filled faces into edges.
+             */
+            if (wireframe)
             {
-                GL.LineWidth(2f);
-                GL.DrawArrays(PrimitiveType.LineStrip, 0, indexCount);
+                GL.PolygonMode(
+                    TriangleFace.FrontAndBack,
+                    PolygonMode.Line);
             }
-            else
+
+            GL.DrawElements(
+                PrimitiveType.Triangles,
+                _elementCount,
+                DrawElementsType.UnsignedInt,
+                0);
+
+            if (wireframe)
             {
-                var mode = wireframe ? PrimitiveType.Lines : PrimitiveType.Triangles;
-                if (wireframe)
-                {
-                    // GPU-level wireframe (optional). Alternatively, draw edges—this is simple:
-                    GL.PolygonMode(TriangleFace.FrontAndBack, PolygonMode.Line);
-                }
-                GL.DrawElements(mode, indexCount, DrawElementsType.UnsignedInt, 0);
-                if (wireframe)
-                    GL.PolygonMode(TriangleFace.FrontAndBack, PolygonMode.Fill);
+                GL.PolygonMode(
+                    TriangleFace.FrontAndBack,
+                    PolygonMode.Fill);
             }
-
-            GL.BindVertexArray(0);
-            GL.UseProgram(0);
         }
 
-        public void Dispose()
+        GL.BindVertexArray(0);
+        GL.UseProgram(0);
+    }
+
+    public void Dispose()
+    {
+        GL.DeleteBuffer(
+            _elementBuffer);
+
+        GL.DeleteBuffer(
+            _normalBuffer);
+
+        GL.DeleteBuffer(
+            _positionBuffer);
+
+        GL.DeleteVertexArray(
+            _vao);
+
+        GL.DeleteProgram(
+            _program);
+    }
+
+    private static int CreateProgram(
+        string vertexShaderSource,
+        string fragmentShaderSource)
+    {
+        int vertexShader =
+            CompileShader(
+                ShaderType.VertexShader,
+                vertexShaderSource);
+
+        int fragmentShader =
+            CompileShader(
+                ShaderType.FragmentShader,
+                fragmentShaderSource);
+
+        int program =
+            GL.CreateProgram();
+
+        GL.AttachShader(
+            program,
+            vertexShader);
+
+        GL.AttachShader(
+            program,
+            fragmentShader);
+
+        GL.LinkProgram(program);
+
+        GL.GetProgram(
+            program,
+            GetProgramParameterName.LinkStatus,
+            out int linkSucceeded);
+
+        string linkLog =
+            GL.GetProgramInfoLog(program);
+
+        GL.DetachShader(
+            program,
+            vertexShader);
+
+        GL.DetachShader(
+            program,
+            fragmentShader);
+
+        GL.DeleteShader(
+            vertexShader);
+
+        GL.DeleteShader(
+            fragmentShader);
+
+        if (linkSucceeded == 0)
         {
-            if (ebo != 0) GL.DeleteBuffer(ebo);
-            if (vboNrm != 0) GL.DeleteBuffer(vboNrm);
-            if (vboPos != 0) GL.DeleteBuffer(vboPos);
-            if (vao != 0) GL.DeleteVertexArray(vao);
-            if (program != 0) GL.DeleteProgram(program);
+            GL.DeleteProgram(program);
+
+            throw new InvalidOperationException(
+                "SurfaceRenderer program link failed: " +
+                linkLog);
         }
 
-        private static int Compile(string vs, string fs)
+        return program;
+    }
+
+    private static int CompileShader(
+        ShaderType shaderType,
+        string source)
+    {
+        int shader =
+            GL.CreateShader(shaderType);
+
+        GL.ShaderSource(
+            shader,
+            source);
+
+        GL.CompileShader(shader);
+
+        GL.GetShader(
+            shader,
+            ShaderParameter.CompileStatus,
+            out int compileSucceeded);
+
+        if (compileSucceeded == 0)
         {
-            int v = GL.CreateShader(ShaderType.VertexShader);
-            GL.ShaderSource(v, vs); GL.CompileShader(v); GL.GetShader(v, ShaderParameter.CompileStatus, out int okV);
-            if (okV == 0) throw new InvalidOperationException("VS: " + GL.GetShaderInfoLog(v));
+            string log =
+                GL.GetShaderInfoLog(shader);
 
-            int f = GL.CreateShader(ShaderType.FragmentShader);
-            GL.ShaderSource(f, fs); GL.CompileShader(f); GL.GetShader(f, ShaderParameter.CompileStatus, out int okF);
-            if (okF == 0) throw new InvalidOperationException("FS: " + GL.GetShaderInfoLog(f));
+            GL.DeleteShader(shader);
 
-            int p = GL.CreateProgram();
-            GL.AttachShader(p, v); GL.AttachShader(p, f); GL.LinkProgram(p);
-            GL.GetProgram(p, GetProgramParameterName.LinkStatus, out int okP);
-            GL.DeleteShader(v); GL.DeleteShader(f);
-            if (okP == 0) throw new InvalidOperationException("Link: " + GL.GetProgramInfoLog(p));
-            return p;
+            throw new InvalidOperationException(
+                $"SurfaceRenderer {shaderType} compilation failed: {log}");
         }
+
+        return shader;
     }
 }

--- a/src/Rendering/Visualize3D/SurfaceFactory.cs
+++ b/src/Rendering/Visualize3D/SurfaceFactory.cs
@@ -1,100 +1,465 @@
-﻿//C:/Users/sebas/source/repos/Fluxion/Rendering/Visualize3D/SurfaceFactory.cs
-using Fluxion.src.Numerics.Functions3D;
-using OpenTK.Mathematics;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace Fluxion.src.Rendering.Visualize3D
+using Fluxion.src.Numerics.Functions3D;
+
+using OpenTK.Mathematics;
+
+namespace Fluxion.src.Rendering.Visualize3D;
+
+public static class SurfaceFactory
 {
-    public static class SurfaceFactory
+    private const double MaximumAbsoluteHeight =
+        1_000_000.0;
+
+    public static Mesh3D BuildSurface(
+        IScalarField scalarField,
+        int gridResolution,
+        double xMin,
+        double xMax,
+        double yMin,
+        double yMax)
     {
-        public static Mesh3D BuildSurface
-        (   IScalarField scalarField,int gridResolution,
-            double xMin, double xMax, 
-            double yMin, double yMax
-        )
+        ArgumentNullException.ThrowIfNull(
+            scalarField);
+
+        ValidateRange(
+            xMin,
+            xMax,
+            nameof(xMin),
+            nameof(xMax));
+
+        ValidateRange(
+            yMin,
+            yMax,
+            nameof(yMin),
+            nameof(yMax));
+
+        gridResolution =
+            Math.Clamp(
+                gridResolution,
+                2,
+                400);
+
+        int xSamples = gridResolution;
+        int ySamples = gridResolution;
+
+        int vertexCount =
+            xSamples * ySamples;
+
+        var positions =
+            new Vector3[vertexCount];
+
+        var normals =
+            new Vector3[vertexCount];
+
+        var valid =
+            new bool[vertexCount];
+
+        var heights =
+            new double[vertexCount];
+
+        double stepX =
+            (xMax - xMin) /
+            (xSamples - 1);
+
+        double stepY =
+            (yMax - yMin) /
+            (ySamples - 1);
+
+        for (int row = 0;
+             row < ySamples;
+             row++)
         {
-            gridResolution = System.Math.Max(2, gridResolution);
+            double y =
+                yMin + (row * stepY);
 
-            int xSamples = gridResolution, ySamples = gridResolution;
-            int vertexCount = xSamples * ySamples;
-            var positions = new Vector3[vertexCount];
-            var normals = new Vector3[vertexCount];
-
-            double stepX = (xMax - xMin) / (xSamples - 1);
-            double stepY = (yMax - yMin) / (ySamples - 1);
-
-            for (int Positions = 0; Positions < ySamples; Positions++)
+            for (int column = 0;
+                 column < xSamples;
+                 column++)
             {
-                double y = yMin + Positions * stepY;
-                for (int i = 0; i < xSamples; i++)
-                {
-                    double x = xMin + i * stepX;
-                    double z = scalarField.Evaluate(x, y);
-                    int idx = Positions * xSamples + i;
-                    positions[idx] = new Vector3((float)x, (float)z, (float)y); // note: Y<-Z, Z<-Y (Y up)
-                }
+                double x =
+                    xMin + (column * stepX);
+
+                int index =
+                    (row * xSamples) +
+                    column;
+
+                bool isValid =
+                    TryEvaluate(
+                        scalarField,
+                        x,
+                        y,
+                        out double z);
+
+                valid[index] =
+                    isValid;
+
+                heights[index] =
+                    z;
+
+                /*
+                 * OpenTK uses Y as the vertical world axis.
+                 *
+                 * Mathematical coordinates:
+                 * x -> world X
+                 * y -> world Z
+                 * z -> world Y
+                 */
+                positions[index] =
+                    new Vector3(
+                        (float)x,
+                        isValid ? (float)z : 0.0f,
+                        (float)y);
             }
-
-            for (int j = 0; j < ySamples; j++)
-            {
-                for (int i = 0; i < xSamples; i++)
-                {
-                    int vertexIndex = j * xSamples + i;
-
-                    int leftIndex = System.Math.Max(i - 1, 0), rightIndex = System.Math.Min(i + 1, xSamples - 1);
-                    int bottomIndex = System.Math.Max(j - 1, 0), topIndex = System.Math.Min(j + 1, ySamples - 1);
-
-                    var leftPos = positions[j * xSamples + leftIndex];
-                    var rightPos = positions[j * xSamples + rightIndex];
-                    var bottomPos = positions[bottomIndex * xSamples + i];
-                    var topPos = positions[topIndex * xSamples + i];
-
-                    var xDir = rightPos - leftPos;
-                    var yDir = topPos - bottomPos;
-                    var normal = Vector3.Normalize(Vector3.Cross(yDir, xDir));
-                    normals[vertexIndex] = normal;
-                }
-            }
-
-            int triangleCount = (xSamples - 1) * (ySamples - 1) * 2;
-            var indices = new int[triangleCount * 3];
-            int indexCursor = 0;
-            for (int j = 0; j < ySamples - 1; j++)
-            {
-                for (int i = 0; i < xSamples - 1; i++)
-                {
-                    int v00 = j * xSamples + i;
-                    int v10 = j * xSamples + i + 1;
-                    int v01 = (j + 1) * xSamples + i;
-                    int v11 = (j + 1) * xSamples + i + 1;
-
-                    indices[indexCursor++] = v00; indices[indexCursor++] = v01; 
-                    indices[indexCursor++] = v10; indices[indexCursor++] = v10; 
-                    indices[indexCursor++] = v01; indices[indexCursor++] = v11;
-                }
-            }
-
-            return new Mesh3D { Positions = positions, Normals = normals, Indices = indices };
         }
 
-        public static Mesh3D BuildPolyline
-        (
-            Func<double, Vector3d> curveFunction, double tMin, double tMax, int samplesCount
-        )
+        BuildNormals(
+            positions,
+            normals,
+            valid,
+            xSamples,
+            ySamples);
+
+        double robustHeightScale =
+            CalculateRobustHeightScale(
+                heights,
+                valid);
+
+        var indices =
+            BuildIndices(
+                heights,
+                valid,
+                xSamples,
+                ySamples,
+                robustHeightScale);
+
+        return new Mesh3D
         {
-            samplesCount = System.Math.Max(2, samplesCount);
-            var sampledPoints = new Vector3[samplesCount];
-            double tStep = (tMax - tMin) / (samplesCount - 1);
+            Positions = positions,
+            Normals = normals,
+            Indices = indices.ToArray()
+        };
+    }
 
-            for (int i = 0; i < samplesCount; i++)
+    public static Mesh3D BuildPolyline(
+        Func<double, Vector3d> curveFunction,
+        double tMin,
+        double tMax,
+        int samplesCount)
+    {
+        ArgumentNullException.ThrowIfNull(
+            curveFunction);
+
+        ValidateRange(
+            tMin,
+            tMax,
+            nameof(tMin),
+            nameof(tMax));
+
+        samplesCount =
+            Math.Max(
+                2,
+                samplesCount);
+
+        var sampledPoints =
+            new Vector3[samplesCount];
+
+        double tStep =
+            (tMax - tMin) /
+            (samplesCount - 1);
+
+        for (int index = 0;
+             index < samplesCount;
+             index++)
+        {
+            double t =
+                tMin + (index * tStep);
+
+            Vector3d point =
+                curveFunction(t);
+
+            sampledPoints[index] =
+                new Vector3(
+                    (float)point.X,
+                    (float)point.Z,
+                    (float)point.Y);
+        }
+
+        return new Mesh3D
+        {
+            Positions = sampledPoints,
+            Normals = Array.Empty<Vector3>(),
+            Indices = Array.Empty<int>()
+        };
+    }
+
+    private static void BuildNormals(
+        IReadOnlyList<Vector3> positions,
+        IList<Vector3> normals,
+        IReadOnlyList<bool> valid,
+        int xSamples,
+        int ySamples)
+    {
+        for (int row = 0;
+             row < ySamples;
+             row++)
+        {
+            for (int column = 0;
+                 column < xSamples;
+                 column++)
             {
-                double t = tMin + i * tStep;
-                var samplePoint = curveFunction(t);
-                sampledPoints[i] = new Vector3((float)samplePoint.X, (float)samplePoint.Z, (float)samplePoint.Y); // keep Y up
-            }
+                int index =
+                    (row * xSamples) +
+                    column;
 
-            // Build degenerate triangle list for a simple line strip (rendered as GL_LINES)
-            return new Mesh3D { Positions = sampledPoints, Normals = Array.Empty<Vector3>(), Indices = Array.Empty<int>() };
+                if (!valid[index])
+                {
+                    normals[index] =
+                        Vector3.UnitY;
+
+                    continue;
+                }
+
+                int leftColumn =
+                    Math.Max(
+                        column - 1,
+                        0);
+
+                int rightColumn =
+                    Math.Min(
+                        column + 1,
+                        xSamples - 1);
+
+                int bottomRow =
+                    Math.Max(
+                        row - 1,
+                        0);
+
+                int topRow =
+                    Math.Min(
+                        row + 1,
+                        ySamples - 1);
+
+                int leftIndex =
+                    (row * xSamples) +
+                    leftColumn;
+
+                int rightIndex =
+                    (row * xSamples) +
+                    rightColumn;
+
+                int bottomIndex =
+                    (bottomRow * xSamples) +
+                    column;
+
+                int topIndex =
+                    (topRow * xSamples) +
+                    column;
+
+                Vector3 center =
+                    positions[index];
+
+                Vector3 left =
+                    valid[leftIndex]
+                        ? positions[leftIndex]
+                        : center;
+
+                Vector3 right =
+                    valid[rightIndex]
+                        ? positions[rightIndex]
+                        : center;
+
+                Vector3 bottom =
+                    valid[bottomIndex]
+                        ? positions[bottomIndex]
+                        : center;
+
+                Vector3 top =
+                    valid[topIndex]
+                        ? positions[topIndex]
+                        : center;
+
+                Vector3 xDirection =
+                    right - left;
+
+                Vector3 yDirection =
+                    top - bottom;
+
+                Vector3 normal =
+                    Vector3.Cross(
+                        yDirection,
+                        xDirection);
+
+                normals[index] =
+                    normal.LengthSquared >
+                    0.0000001f
+                        ? Vector3.Normalize(normal)
+                        : Vector3.UnitY;
+            }
+        }
+    }
+
+    private static List<int> BuildIndices(
+        IReadOnlyList<double> heights,
+        IReadOnlyList<bool> valid,
+        int xSamples,
+        int ySamples,
+        double robustHeightScale)
+    {
+        var indices =
+            new List<int>(
+                (xSamples - 1) *
+                (ySamples - 1) *
+                6);
+
+        for (int row = 0;
+             row < ySamples - 1;
+             row++)
+        {
+            for (int column = 0;
+                 column < xSamples - 1;
+                 column++)
+            {
+                int v00 =
+                    (row * xSamples) +
+                    column;
+
+                int v10 =
+                    v00 + 1;
+
+                int v01 =
+                    ((row + 1) * xSamples) +
+                    column;
+
+                int v11 =
+                    v01 + 1;
+
+                if (!valid[v00] ||
+                    !valid[v10] ||
+                    !valid[v01] ||
+                    !valid[v11])
+                {
+                    continue;
+                }
+
+                double minimum =
+                    Math.Min(
+                        Math.Min(
+                            heights[v00],
+                            heights[v10]),
+                        Math.Min(
+                            heights[v01],
+                            heights[v11]));
+
+                double maximum =
+                    Math.Max(
+                        Math.Max(
+                            heights[v00],
+                            heights[v10]),
+                        Math.Max(
+                            heights[v01],
+                            heights[v11]));
+
+                /*
+                 * Avoid triangles that bridge a likely vertical
+                 * discontinuity. This is deliberately conservative.
+                 */
+                double maximumAllowedJump =
+                    Math.Max(
+                        10.0,
+                        robustHeightScale * 20.0);
+
+                if (maximum - minimum >
+                    maximumAllowedJump)
+                {
+                    continue;
+                }
+
+                indices.Add(v00);
+                indices.Add(v01);
+                indices.Add(v10);
+
+                indices.Add(v10);
+                indices.Add(v01);
+                indices.Add(v11);
+            }
+        }
+
+        return indices;
+    }
+
+    private static bool TryEvaluate(
+        IScalarField scalarField,
+        double x,
+        double y,
+        out double z)
+    {
+        try
+        {
+            z =
+                scalarField.Evaluate(
+                    x,
+                    y);
+
+            return
+                double.IsFinite(z) &&
+                Math.Abs(z) <=
+                MaximumAbsoluteHeight;
+        }
+        catch
+        {
+            z = double.NaN;
+            return false;
+        }
+    }
+
+    private static double CalculateRobustHeightScale(
+        IReadOnlyList<double> heights,
+        IReadOnlyList<bool> valid)
+    {
+        double[] magnitudes =
+            heights
+                .Where(
+                    (_, index) =>
+                        valid[index])
+                .Select(Math.Abs)
+                .OrderBy(value => value)
+                .ToArray();
+
+        if (magnitudes.Length == 0)
+        {
+            return 1.0;
+        }
+
+        int percentileIndex =
+            (int)Math.Floor(
+                (magnitudes.Length - 1) *
+                0.80);
+
+        return Math.Max(
+            1.0e-6,
+            magnitudes[percentileIndex]);
+    }
+
+    private static void ValidateRange(
+        double minimum,
+        double maximum,
+        string minimumName,
+        string maximumName)
+    {
+        if (!double.IsFinite(minimum) ||
+            !double.IsFinite(maximum))
+        {
+            throw new ArgumentException(
+                "Surface bounds must be finite.");
+        }
+
+        if (minimum >= maximum)
+        {
+            throw new ArgumentException(
+                $"{minimumName} must be smaller than {maximumName}.");
         }
     }
 }


### PR DESCRIPTION
This pull request connects Fluxion’s existing 3D rendering components to the WPF desktop viewport and expands the mathematical expression engine to support two-variable surface functions.

Previously, the desktop application supported scalar calculations and 2D functions of x, while the 3D surface renderer could only be used through a separate OpenTK window. This update integrates the 3D mesh, camera, axes, surface renderer, and expression evaluator into the main WPF interface.

Users can now select 3D Surface and enter expressions such as:
z = sin(x) * cos(y)
z = x^2 + y^2
f(x,y) = exp(-(x^2 + y^2))